### PR TITLE
feat(nvim): use telescope-projects to switch projects

### DIFF
--- a/nvim-fredrik/lua/config/keymaps.lua
+++ b/nvim-fredrik/lua/config/keymaps.lua
@@ -315,7 +315,8 @@ function M.setup_telescope_keymaps()
   map_normal_mode("<leader><leader>", require("telescope.builtin").find_files, "Find Files")
 
   -- file
-  map_normal_mode("<leader>fp", "<cmd>Telescope projects<CR>", "File from other project")
+  map_normal_mode("<leader>fp", "<cmd>Telescope project<CR>", "Change active project")
+  map_normal_mode("<leader>fP", "<cmd>Telescope projects<CR>", "File from other project")
   map_normal_mode("<leader>fr", "<cmd>Telescope oldfiles<CR>", "Recent files")
 
   -- git

--- a/nvim-fredrik/lua/plugins/copilot.lua
+++ b/nvim-fredrik/lua/plugins/copilot.lua
@@ -40,7 +40,11 @@ return {
         end,
       },
     },
-    enabled = require("utils.private").enable_copilot(),
+
+    -- TODO: enabled/disable copilot from project switcher
+    enabled = false,
+    -- enabled = require("utils.private").enable_copilot(),
+
     cmd = "Copilot",
     event = "InsertEnter",
     build = ":Copilot auth",

--- a/nvim-fredrik/lua/plugins/neotree.lua
+++ b/nvim-fredrik/lua/plugins/neotree.lua
@@ -7,11 +7,12 @@ return {
     "MunifTanjim/nui.nvim",
   },
   opts = {
+    close_if_last_window = true,
     sources = { "filesystem", "buffers", "git_status", "document_symbols" },
     -- open_files_do_not_replace_types = { "terminal", "Trouble", "trouble", "qf", "Outline" },
     filesystem = {
-      bind_to_cwd = false,
-      follow_current_file = { enabled = true },
+      bind_to_cwd = true,
+      -- follow_current_file = { enabled = true },
 
       -- This will use the OS level file watchers to detect changes
       -- instead of relying on nvim autocmd events.


### PR DESCRIPTION
This will make telescope-projects switch the project and also:
* Run actual `cd <project>` which could potentially trigger shell extensions etc that modifies the environment.
* Read the updated environment and register those env vars into Neovim itself, including the updated `$PATH`.

This _could_ eliminate the need for tmux in my workflow!