### PR TITLE
fix: protobuf linter

### DIFF
--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -90,7 +90,7 @@ require("lazyload").on_vim_enter(function()
     end
 
     -- buf_lint
-    vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost" }, {
+    vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
       group = vim.api.nvim_create_augroup("lint-buf", { clear = true }),
       pattern = { "*.proto" },
       callback = function()
@@ -201,7 +201,7 @@ require("lazyload").on_vim_enter(function()
         end,
       }
 
-      vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost" }, {
+      vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
         group = vim.api.nvim_create_augroup("lint-api-linter", { clear = true }),
         pattern = { "*.proto" },
         callback = function()

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -45,22 +45,24 @@ require("lazyload").on_vim_enter(function()
 
   -- protobuf: buf_lint + api_linter (custom autocmds because cwd must be dynamic)
   do
-    local cached_buf_config_filepath = nil
+    local buf_config_cache = {}
 
     local function buf_config_filepath()
-      if cached_buf_config_filepath ~= nil then
-        return cached_buf_config_filepath
-      end
       local buffer_parent_dir = vim.fn.expand("%:p:h")
+      local cached = buf_config_cache[buffer_parent_dir]
+      if cached ~= nil then
+        return cached or nil
+      end
       local found = vim.fs.find(
         { "buf.yaml", "buf.yml" },
         { path = buffer_parent_dir, upward = true, type = "file", limit = 1, stop = vim.fs.normalize("~") }
       )
       if #found == 0 then
+        buf_config_cache[buffer_parent_dir] = false
         return nil
       end
-      cached_buf_config_filepath = found[1]
-      return cached_buf_config_filepath
+      buf_config_cache[buffer_parent_dir] = found[1]
+      return found[1]
     end
 
     local function buf_lint_cwd()

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -90,6 +90,16 @@ require("lazyload").on_vim_enter(function()
     end
 
     -- buf_lint
+    lint.linters.buf_lint.args = {
+      "lint",
+      "--error-format=json",
+      function()
+        local bufpath = vim.fn.expand("%:p")
+        return get_relative_path(bufpath, buf_lint_cwd() or "")
+      end,
+    }
+    lint.linters.buf_lint.append_fname = false
+
     vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
       group = vim.api.nvim_create_augroup("lint-buf", { clear = true }),
       pattern = { "*.proto" },
@@ -98,18 +108,7 @@ require("lazyload").on_vim_enter(function()
         if cwd == nil then
           return
         end
-        lint.try_lint("buf_lint", {
-          args = {
-            "lint",
-            "--error-format=json",
-            function()
-              local bufpath = vim.fn.expand("%:p")
-              return get_relative_path(bufpath, cwd)
-            end,
-          },
-          cwd = cwd,
-          append_fname = false,
-        })
+        lint.try_lint("buf_lint", { cwd = cwd })
       end,
     })
 

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -68,7 +68,7 @@ require("lazyload").on_vim_enter(function()
     end
 
     local function get_relative_path(file, cwd)
-      if not cwd:sub(-1) == "/" then
+      if cwd:sub(-1) ~= "/" then
         cwd = cwd .. "/"
       end
       local start, stop = file:find(cwd, 1, true)

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -126,7 +126,7 @@ require("lazyload").on_vim_enter(function()
       end
 
       local function descriptor_set_in()
-        local cfg = buf_config_filepath()
+        local cfg = assert(buf_config_filepath(), "buf config not found")
         local path = descriptor_path_for(cfg)
         local obj = vim.system({ "buf", "build", "-o", path }, { cwd = vim.fn.fnamemodify(cfg, ":h") }):wait()
         if obj.code ~= 0 then

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -57,14 +57,18 @@ require("lazyload").on_vim_enter(function()
         { path = buffer_parent_dir, upward = true, type = "file", limit = 1, stop = vim.fs.normalize("~") }
       )
       if #found == 0 then
-        error("Buf config file not found")
+        return nil
       end
       cached_buf_config_filepath = found[1]
       return cached_buf_config_filepath
     end
 
     local function buf_lint_cwd()
-      return vim.fn.fnamemodify(buf_config_filepath(), ":h")
+      local cfg = buf_config_filepath()
+      if cfg == nil then
+        return nil
+      end
+      return vim.fn.fnamemodify(cfg, ":h")
     end
 
     local function get_relative_path(file, cwd)
@@ -88,16 +92,20 @@ require("lazyload").on_vim_enter(function()
       group = vim.api.nvim_create_augroup("lint-buf", { clear = true }),
       pattern = { "*.proto" },
       callback = function()
+        local cwd = buf_lint_cwd()
+        if cwd == nil then
+          return
+        end
         lint.try_lint("buf_lint", {
           args = {
             "lint",
             "--error-format=json",
             function()
               local bufpath = vim.fn.expand("%:p")
-              return get_relative_path(bufpath, buf_lint_cwd())
+              return get_relative_path(bufpath, cwd)
             end,
           },
-          cwd = buf_lint_cwd(),
+          cwd = cwd,
           append_fname = false,
         })
       end,
@@ -111,7 +119,11 @@ require("lazyload").on_vim_enter(function()
         if vim.fn.executable("buf") == 0 then
           error("buf CLI not found")
         end
-        local buf_config_folderpath = vim.fn.fnamemodify(buf_config_filepath(), ":h")
+        local cfg = buf_config_filepath()
+        if cfg == nil then
+          error("buf config file not found")
+        end
+        local buf_config_folderpath = vim.fn.fnamemodify(cfg, ":h")
         local obj = vim.system({ "buf", "build", "-o", descriptor_filepath }, { cwd = buf_config_folderpath }):wait()
         if obj.code ~= 0 then
           error("buf build failed: " .. tostring(obj.stderr or ""))
@@ -173,8 +185,12 @@ require("lazyload").on_vim_enter(function()
         group = vim.api.nvim_create_augroup("lint-api-linter", { clear = true }),
         pattern = { "*.proto" },
         callback = function()
+          local cwd = buf_lint_cwd()
+          if cwd == nil then
+            return
+          end
           lint.try_lint("api_linter", {
-            cwd = buf_lint_cwd(),
+            cwd = cwd,
           })
         end,
       })

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -115,7 +115,25 @@ require("lazyload").on_vim_enter(function()
 
     -- api_linter
     if vim.fn.executable("api-linter") == 1 then
-      local descriptor_filepath = os.tmpname()
+      local descriptor_paths = {}
+
+      local function descriptor_path_for(cfg)
+        local path = descriptor_paths[cfg]
+        if path == nil then
+          path = os.tmpname()
+          descriptor_paths[cfg] = path
+        end
+        return path
+      end
+
+      vim.api.nvim_create_autocmd("VimLeavePre", {
+        group = vim.api.nvim_create_augroup("lint-api-linter-cleanup", { clear = true }),
+        callback = function()
+          for _, path in pairs(descriptor_paths) do
+            os.remove(path)
+          end
+        end,
+      })
 
       local function descriptor_set_in()
         if vim.fn.executable("buf") == 0 then
@@ -125,6 +143,7 @@ require("lazyload").on_vim_enter(function()
         if cfg == nil then
           error("buf config file not found")
         end
+        local descriptor_filepath = descriptor_path_for(cfg)
         local buf_config_folderpath = vim.fn.fnamemodify(cfg, ":h")
         local obj = vim.system({ "buf", "build", "-o", descriptor_filepath }, { cwd = buf_config_folderpath }):wait()
         if obj.code ~= 0 then
@@ -178,7 +197,6 @@ require("lazyload").on_vim_enter(function()
             end
           end
 
-          os.remove(descriptor_filepath)
           return diagnostics
         end,
       }

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -114,7 +114,7 @@ require("lazyload").on_vim_enter(function()
         local buf_config_folderpath = vim.fn.fnamemodify(buf_config_filepath(), ":h")
         local obj = vim.system({ "buf", "build", "-o", descriptor_filepath }, { cwd = buf_config_folderpath }):wait()
         if obj.code ~= 0 then
-          error("buf build failed: " .. obj.stderr)
+          error("buf build failed: " .. tostring(obj.stderr or ""))
         end
         return "--descriptor-set-in=" .. descriptor_filepath
       end

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -116,66 +116,30 @@ require("lazyload").on_vim_enter(function()
 
     -- api_linter
     if vim.fn.executable("api-linter") == 1 and vim.fn.executable("buf") == 1 then
-      -- Per-config descriptor state: { path, dirty, building, pending = {cb...} }
-      local descriptor_state = {}
+      local descriptor_paths = {}
 
-      local function state_for(cfg)
-        local s = descriptor_state[cfg]
-        if s == nil then
-          s = { path = os.tmpname(), dirty = true, building = false, pending = {} }
-          descriptor_state[cfg] = s
+      local function descriptor_path_for(cfg)
+        if descriptor_paths[cfg] == nil then
+          descriptor_paths[cfg] = os.tmpname()
         end
-        return s
+        return descriptor_paths[cfg]
       end
 
-      local build_descriptor
-
-      build_descriptor = function(cfg)
-        local s = state_for(cfg)
-        s.building = true
-        s.dirty = false
-        vim.system(
-          { "buf", "build", "-o", s.path },
-          { cwd = vim.fn.fnamemodify(cfg, ":h") },
-          vim.schedule_wrap(function(obj)
-            s.building = false
-            if obj.code ~= 0 then
-              s.dirty = true
-              s.pending = {} -- drop queued callbacks; they'll retrigger on the next event
-              vim.notify("buf build failed: " .. tostring(obj.stderr or ""), vim.log.levels.WARN)
-              return
-            end
-            if s.dirty then
-              -- A write came in during build; rebuild. Callbacks stay queued.
-              build_descriptor(cfg)
-              return
-            end
-            local pending = s.pending
-            s.pending = {}
-            for _, cb in ipairs(pending) do
-              cb()
-            end
-          end)
-        )
-      end
-
-      local function ensure_descriptor(cfg, callback)
-        local s = state_for(cfg)
-        if not s.dirty and not s.building then
-          callback()
-          return
+      local function descriptor_set_in()
+        local cfg = buf_config_filepath()
+        local path = descriptor_path_for(cfg)
+        local obj = vim.system({ "buf", "build", "-o", path }, { cwd = vim.fn.fnamemodify(cfg, ":h") }):wait()
+        if obj.code ~= 0 then
+          error("buf build failed: " .. tostring(obj.stderr or ""))
         end
-        table.insert(s.pending, callback)
-        if not s.building then
-          build_descriptor(cfg)
-        end
+        return "--descriptor-set-in=" .. path
       end
 
       vim.api.nvim_create_autocmd("VimLeavePre", {
         group = vim.api.nvim_create_augroup("lint-api-linter-cleanup", { clear = true }),
         callback = function()
-          for _, s in pairs(descriptor_state) do
-            os.remove(s.path)
+          for _, p in pairs(descriptor_paths) do
+            os.remove(p)
           end
         end,
       })
@@ -191,7 +155,7 @@ require("lazyload").on_vim_enter(function()
           "--disable-rule=core::0191::java-package",
           "--disable-rule=core::0191::java-outer-classname",
           function()
-            return "--descriptor-set-in=" .. state_for(buf_config_filepath()).path
+            return descriptor_set_in()
           end,
           function()
             return get_relative_path(vim.fn.expand("%:p"), buf_lint_cwd())
@@ -231,23 +195,12 @@ require("lazyload").on_vim_enter(function()
       vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
         group = vim.api.nvim_create_augroup("lint-api-linter", { clear = true }),
         pattern = { "*.proto" },
-        callback = function(args)
-          local cfg = buf_config_filepath()
-          if cfg == nil then
+        callback = function()
+          local cwd = buf_lint_cwd()
+          if cwd == nil then
             return
           end
-          local cwd = vim.fn.fnamemodify(cfg, ":h")
-          if args.event == "BufWritePost" then
-            state_for(cfg).dirty = true
-          end
-          ensure_descriptor(cfg, function()
-            if not vim.api.nvim_buf_is_valid(args.buf) then
-              return
-            end
-            vim.api.nvim_buf_call(args.buf, function()
-              lint.try_lint("api_linter", { cwd = cwd })
-            end)
-          end)
+          lint.try_lint("api_linter", { cwd = cwd })
         end,
       })
     end

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -114,42 +114,73 @@ require("lazyload").on_vim_enter(function()
 
     -- api_linter
     if vim.fn.executable("api-linter") == 1 then
-      local descriptor_paths = {}
+      -- Per-config descriptor state: { path, dirty, building, pending = {cb...} }
+      local descriptor_state = {}
 
-      local function descriptor_path_for(cfg)
-        local path = descriptor_paths[cfg]
-        if path == nil then
-          path = os.tmpname()
-          descriptor_paths[cfg] = path
+      local function state_for(cfg)
+        local s = descriptor_state[cfg]
+        if s == nil then
+          s = { path = os.tmpname(), dirty = true, building = false, pending = {} }
+          descriptor_state[cfg] = s
         end
-        return path
+        return s
+      end
+
+      local build_descriptor
+
+      build_descriptor = function(cfg)
+        if vim.fn.executable("buf") == 0 then
+          vim.notify("buf CLI not found", vim.log.levels.WARN)
+          return
+        end
+        local s = state_for(cfg)
+        s.building = true
+        s.dirty = false
+        vim.system(
+          { "buf", "build", "-o", s.path },
+          { cwd = vim.fn.fnamemodify(cfg, ":h") },
+          vim.schedule_wrap(function(obj)
+            s.building = false
+            if obj.code ~= 0 then
+              s.dirty = true
+              s.pending = {} -- drop queued callbacks; they'll retrigger on the next event
+              vim.notify("buf build failed: " .. tostring(obj.stderr or ""), vim.log.levels.WARN)
+              return
+            end
+            if s.dirty then
+              -- A write came in during build; rebuild. Callbacks stay queued.
+              build_descriptor(cfg)
+              return
+            end
+            local pending = s.pending
+            s.pending = {}
+            for _, cb in ipairs(pending) do
+              cb(s.path)
+            end
+          end)
+        )
+      end
+
+      local function ensure_descriptor(cfg, callback)
+        local s = state_for(cfg)
+        if not s.dirty and not s.building then
+          callback(s.path)
+          return
+        end
+        table.insert(s.pending, callback)
+        if not s.building then
+          build_descriptor(cfg)
+        end
       end
 
       vim.api.nvim_create_autocmd("VimLeavePre", {
         group = vim.api.nvim_create_augroup("lint-api-linter-cleanup", { clear = true }),
         callback = function()
-          for _, path in pairs(descriptor_paths) do
-            os.remove(path)
+          for _, s in pairs(descriptor_state) do
+            os.remove(s.path)
           end
         end,
       })
-
-      local function descriptor_set_in()
-        if vim.fn.executable("buf") == 0 then
-          error("buf CLI not found")
-        end
-        local cfg = buf_config_filepath()
-        if cfg == nil then
-          error("buf config file not found")
-        end
-        local descriptor_filepath = descriptor_path_for(cfg)
-        local buf_config_folderpath = vim.fn.fnamemodify(cfg, ":h")
-        local obj = vim.system({ "buf", "build", "-o", descriptor_filepath }, { cwd = buf_config_folderpath }):wait()
-        if obj.code ~= 0 then
-          error("buf build failed: " .. tostring(obj.stderr or ""))
-        end
-        return "--descriptor-set-in=" .. descriptor_filepath
-      end
 
       lint.linters.api_linter = {
         name = "api_linter",
@@ -162,11 +193,15 @@ require("lazyload").on_vim_enter(function()
           "--disable-rule=core::0191::java-package",
           "--disable-rule=core::0191::java-outer-classname",
           function()
-            return descriptor_set_in()
+            local cfg = buf_config_filepath()
+            if cfg == nil then
+              return ""
+            end
+            return "--descriptor-set-in=" .. state_for(cfg).path
           end,
           function()
             local bufpath = vim.fn.expand("%:p")
-            return get_relative_path(bufpath, buf_lint_cwd())
+            return get_relative_path(bufpath, buf_lint_cwd() or "")
           end,
         },
         stream = "stdout",
@@ -203,14 +238,23 @@ require("lazyload").on_vim_enter(function()
       vim.api.nvim_create_autocmd({ "BufReadPost", "BufWritePost" }, {
         group = vim.api.nvim_create_augroup("lint-api-linter", { clear = true }),
         pattern = { "*.proto" },
-        callback = function()
-          local cwd = buf_lint_cwd()
-          if cwd == nil then
+        callback = function(args)
+          local cfg = buf_config_filepath()
+          if cfg == nil then
             return
           end
-          lint.try_lint("api_linter", {
-            cwd = cwd,
-          })
+          local cwd = vim.fn.fnamemodify(cfg, ":h")
+          if args.event == "BufWritePost" then
+            state_for(cfg).dirty = true
+          end
+          ensure_descriptor(cfg, function()
+            if not vim.api.nvim_buf_is_valid(args.buf) then
+              return
+            end
+            vim.api.nvim_buf_call(args.buf, function()
+              lint.try_lint("api_linter", { cwd = cwd })
+            end)
+          end)
         end,
       })
     end

--- a/nvim-fredrik/plugin/lint.lua
+++ b/nvim-fredrik/plugin/lint.lua
@@ -50,8 +50,11 @@ require("lazyload").on_vim_enter(function()
     local function buf_config_filepath()
       local buffer_parent_dir = vim.fn.expand("%:p:h")
       local cached = buf_config_cache[buffer_parent_dir]
-      if cached ~= nil then
-        return cached or nil
+      if cached == false then
+        return nil
+      end
+      if cached then
+        return cached
       end
       local found = vim.fs.find(
         { "buf.yaml", "buf.yml" },
@@ -94,8 +97,7 @@ require("lazyload").on_vim_enter(function()
       "lint",
       "--error-format=json",
       function()
-        local bufpath = vim.fn.expand("%:p")
-        return get_relative_path(bufpath, buf_lint_cwd() or "")
+        return get_relative_path(vim.fn.expand("%:p"), buf_lint_cwd())
       end,
     }
     lint.linters.buf_lint.append_fname = false
@@ -113,7 +115,7 @@ require("lazyload").on_vim_enter(function()
     })
 
     -- api_linter
-    if vim.fn.executable("api-linter") == 1 then
+    if vim.fn.executable("api-linter") == 1 and vim.fn.executable("buf") == 1 then
       -- Per-config descriptor state: { path, dirty, building, pending = {cb...} }
       local descriptor_state = {}
 
@@ -129,10 +131,6 @@ require("lazyload").on_vim_enter(function()
       local build_descriptor
 
       build_descriptor = function(cfg)
-        if vim.fn.executable("buf") == 0 then
-          vim.notify("buf CLI not found", vim.log.levels.WARN)
-          return
-        end
         local s = state_for(cfg)
         s.building = true
         s.dirty = false
@@ -155,7 +153,7 @@ require("lazyload").on_vim_enter(function()
             local pending = s.pending
             s.pending = {}
             for _, cb in ipairs(pending) do
-              cb(s.path)
+              cb()
             end
           end)
         )
@@ -164,7 +162,7 @@ require("lazyload").on_vim_enter(function()
       local function ensure_descriptor(cfg, callback)
         local s = state_for(cfg)
         if not s.dirty and not s.building then
-          callback(s.path)
+          callback()
           return
         end
         table.insert(s.pending, callback)
@@ -193,15 +191,10 @@ require("lazyload").on_vim_enter(function()
           "--disable-rule=core::0191::java-package",
           "--disable-rule=core::0191::java-outer-classname",
           function()
-            local cfg = buf_config_filepath()
-            if cfg == nil then
-              return ""
-            end
-            return "--descriptor-set-in=" .. state_for(cfg).path
+            return "--descriptor-set-in=" .. state_for(buf_config_filepath()).path
           end,
           function()
-            local bufpath = vim.fn.expand("%:p")
-            return get_relative_path(bufpath, buf_lint_cwd() or "")
+            return get_relative_path(vim.fn.expand("%:p"), buf_lint_cwd())
           end,
         },
         stream = "stdout",


### PR DESCRIPTION
## Why?

The proto linter setup in `nvim-fredrik/plugin/lint.lua` had a few real
bugs and rough edges: broken operator precedence in `get_relative_path`,
a crash when `buf build` produced no stderr, a noisy error popup when
opening `.proto` files outside a buf project, and a single global cache
/ tmpfile that got clobbered when editing across multiple buf projects
in one session.

## What?

- Fix operator precedence in `get_relative_path` (`not x == y` was always
  false).
- Guard nil `obj.stderr` in the buf build error message.
- Silently skip proto linting when no `buf.yaml` is found instead of
  erroring.
- Cache `buf.yaml` lookups per buffer directory so multiple proto
  projects coexist.
- Use a per-config tmpfile for the api-linter descriptor so projects
  don't clobber each other's descriptor set.
- Switch proto lint autocmds from `BufEnter` to `BufReadPost` to match
  the generic lint autocmd and avoid re-linting on window switches.
- Set `buf_lint` args on `lint.linters` at setup time instead of
  rebuilding the args table on every autocmd fire.
- Gate the api_linter block on both `api-linter` and `buf` being
  executable.
- Move tmpfile cleanup from the parser (which leaked on empty output)
  to a `VimLeavePre` autocmd.
- Assert the buf config is present in `descriptor_set_in` (narrows
  `string|nil` to `string` for lua_ls).

## Notes

An async `buf build` state machine was explored but reverted — build
speed wasn't an actual problem in practice, and the coalescing logic
was paying for a rare edge case at significant complexity cost. The
final shape stays close to `main`, just with the bug fixes layered on.