### PR TITLE
feat: replace bun with deno for npm tools and runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,5 @@ nvim_issue
 stow/shared/.config/zed/prompts
 stow/Darwin/Library/Application Support/lazygit/state.yml
 
-# npm-tools installed packages (lockfile bun.lockb IS tracked)
-npm-tools/node_modules/
-
 # Runtime symlink created by stow/shared/.claude-web/web-setup.sh on the web sandbox
 /.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,6 @@ For each language, consult the corresponding file in
 
 ## Gotchas
 
-- **npm packages are macOS-only**: `packageTools.npmPackages` has dynamic
-  linking issues on NixOS — only add npm tools in Darwin configs
 - **Neovim is managed by Bob**, not nixpkgs — binary is at
   `~/.local/share/bob/nvim-bin/nvim`
 - **`stow/` changes take effect immediately** (just re-run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,8 @@ Example locations:
 
 ### Package-Managed Tools (npm and Python)
 
-For CLI tools installed via bun (npm) or uv (Python). Unlike self-managed CLIs,
-these require explicit upgrades via `./rebuild.sh --update-unstable` or
+For CLI tools installed via deno (npm) or uv (Python). Unlike self-managed
+CLIs, these require explicit upgrades via `./rebuild.sh --update-unstable` or
 `--update`.
 
 - **Module**: `nix/shared/home/package-tools.nix`
@@ -89,9 +89,10 @@ these require explicit upgrades via `./rebuild.sh --update-unstable` or
 
 **Adding npm tools:**
 
-1. Add the package to `packageTools.npmPackages` in the appropriate Nix config
+1. Add a `{ package, bin }` entry to `packageTools.npmPackages` in the
+   appropriate Nix config (`bin` is the package.json "bin" name)
 2. Run `./rebuild.sh` to install
-3. Update later: `./rebuild.sh --update-unstable` or `bun update -g`
+3. Update later: `./rebuild.sh --update-unstable` or `npm-tools-upgrade`
 
 **Adding Python CLI tools (via uv):**
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ symlinking.
 # Rebuild system + packages + dotfiles (reproducible, uses flake.lock)
 ./rebuild.sh
 
-# Update ALL flake inputs + upgrade uv tools + upgrade bun packages
+# Update ALL flake inputs + upgrade uv tools + upgrade npm tools
 ./rebuild.sh --update
 
-# Update unstable inputs + upgrade uv tools + upgrade bun packages
+# Update unstable inputs + upgrade uv tools + upgrade npm tools
 ./rebuild.sh --update-unstable
 
 # Dotfiles only (no Nix rebuild)

--- a/extras/README_NIX.md
+++ b/extras/README_NIX.md
@@ -83,7 +83,7 @@ sudo nix --extra-experimental-features "nix-command flakes" run nix-darwin -- sw
 | User packages      | home-manager                  | Per-user    | `nix/shared/home/`                      |
 | User preferences   | home-manager                  | Per-user    | `nix/shared/home/` + host-specific      |
 | Self-managed CLIs  | Native installers (curl/wget) | Per-user    | `nix/shared/home/self-managed-clis.nix` |
-| Package tools      | bun (npm), uv (Python)        | Per-user    | `nix/shared/home/package-tools.nix`     |
+| Package tools      | deno (npm), uv (Python)       | Per-user    | `nix/shared/home/package-tools.nix`     |
 | Host configuration | nix-darwin/NixOS              | System-wide | `nix/hosts/*/configuration.nix`         |
 | System packages    | nix-darwin/NixOS              | System-wide | `nix/shared/system/`                    |
 | System settings    | nix-darwin/NixOS              | System-wide | `nix/shared/system/`                    |
@@ -150,7 +150,7 @@ By default, `./rebuild.sh` aims to be "reproducible" and uses the locked
 `--update` to update all inputs.
 
 ```sh
-# Update unstable/Darwin-related inputs + upgrade uv tools + upgrade bun packages
+# Update unstable/Darwin-related inputs + upgrade uv tools + upgrade npm tools
 ./rebuild.sh --update-unstable
 # Or manually (flake inputs only): nix flake update nixpkgs-unstable nix-darwin home-manager-unstable dotfiles
 

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,39 @@
         "type": "github"
       }
     },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -68,6 +101,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager-rpi": {
       "inputs": {
         "nixpkgs": [
@@ -108,6 +162,28 @@
         "owner": "nix-community",
         "ref": "master",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1784363791,
+        "narHash": "sha256-p9LRSnyqaiaOItDf3rMjWxlPsmLO7YhgBg4zd6nB0lA=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "a76249be5f5c1ce95c3a0e74930cb015d66718a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
         "type": "github"
       }
     },
@@ -162,7 +238,7 @@
         "argononed": "argononed",
         "flake-compat": "flake-compat",
         "nixos-images": "nixos-images",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1779023229,
@@ -181,16 +257,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1784282293,
+        "narHash": "sha256-IpX7tmVJi9seHg5M4Wuexy78bQDlbntVk1HcT9kFts4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "a47c123a609287a012dfc44d281de2dd4ed13394",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -213,6 +289,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1782691344,
         "narHash": "sha256-i5nw9BYYsMDAaOC4J+JmTof6b2GhlyH076awYRNrTV8=",
         "owner": "NixOS",
@@ -233,10 +325,47 @@
         "dotfiles": "dotfiles",
         "home-manager-rpi": "home-manager-rpi",
         "home-manager-unstable": "home-manager-unstable",
+        "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",
         "nixos-raspberrypi": "nixos-raspberrypi",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
             # stable.${system}.xxx
 
             # Unstable packages
-            unstable.${system}.bun
+            unstable.${system}.deno
             unstable.${system}.go_latest
             unstable.${system}.nodejs
             unstable.${system}.pnpm
@@ -101,7 +101,7 @@
             unstable.${system}.ruby
           ];
           shellHook = ''
-            echo -e "\033[32m[dotfiles-toolchain] bun $(bun --version) | $(go version | awk '{print $1" "$3}') | lua $(lua -v 2>&1 | awk '{print $2}') | node $(node -v) (npm $(npm -v)) | pnpm $(pnpm -v) | python $(python --version | awk '{print $2}') | $(ruby -v | cut -d' ' -f1-2)\033[0m"
+            echo -e "\033[32m[dotfiles-toolchain] $(deno --version | awk 'NR==1{print $1" "$2}') | $(go version | awk '{print $1" "$3}') | lua $(lua -v 2>&1 | awk '{print $2}') | node $(node -v) (npm $(npm -v)) | pnpm $(pnpm -v) | python $(python --version | awk '{print $2}') | $(ruby -v | cut -d' ' -f1-2)\033[0m"
           '';
         };
       };

--- a/nix/hosts/plumbus/users/fredrik.nix
+++ b/nix/hosts/plumbus/users/fredrik.nix
@@ -23,7 +23,10 @@ in
 
   # plumbus-specific package-managed tools
   packageTools.npmPackages = [
-    "@googleworkspace/cli"
+    {
+      package = "@googleworkspace/cli";
+      bin = "gws";
+    }
   ];
   packageTools.uvTools = [ ];
 

--- a/nix/hosts/zap/users/fredrik.nix
+++ b/nix/hosts/zap/users/fredrik.nix
@@ -30,7 +30,10 @@ in
 
   # zap-specific package-managed tools
   packageTools.npmPackages = [
-    "@googleworkspace/cli"
+    {
+      package = "@googleworkspace/cli";
+      bin = "gws";
+    }
   ];
   packageTools.uvTools = [ ];
 

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -54,10 +54,10 @@ in
       '' "$HOME/.opencode/bin/opencode")
     ];
 
-    # npm packages via bun (macOS only, mergeable across config levels)
+    # npm packages (mergeable across config levels)
     packageTools.npmPackages = [ ];
 
-    # Python CLI tools via uv (mergeable across config levels)
+    # Python CLI tools (mergeable across config levels)
     packageTools.uvTools = [
       {
         package = "sqlit-tui";
@@ -143,7 +143,7 @@ in
       # ========================================================================
       # Language-specific
       uv
-      unstable.deno # JS/TS runtime; also installs/runs the npm-managed CLI tools
+      unstable.deno
 
       # Generic development
       bfs
@@ -186,11 +186,9 @@ in
       slides
       chafa # Required for showing images in slides
 
-      # AI coding agents from the llm-agents flake input (see flake.nix).
-      # Update via `./rebuild.sh --update-unstable` (or --update).
-      llmAgents.codex # @openai/codex
-      llmAgents.gemini-cli # @google/gemini-cli
-      llmAgents.pi # @earendil-works/pi-coding-agent
+      llmAgents.codex
+      llmAgents.gemini-cli
+      llmAgents.pi
 
       # ========================================================================
       # Infrastructure & Cloud

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -143,6 +143,10 @@ in
       # ========================================================================
       # Language-specific
       uv
+      # Deno installs/runs the npm-managed CLI tools. Unlike node/bun global
+      # installs (FHS shebangs, glibc-linked shims), deno shims are /bin/sh
+      # scripts exec'ing the nix store deno -> works on NixOS. Unstable for
+      # the latest Node-compat fixes (no-op on macOS, where pkgs IS unstable).
       unstable.deno
 
       # Generic development

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -42,7 +42,7 @@ in
     # Self-managed CLI tools (installed once, auto-update thereafter)
     selfManagedCLIs.clis = [
       (mkCurlInstaller "claude" "Claude Code" "https://claude.ai/install.sh" "$HOME/.local/bin/claude")
-      (mkCurlInstaller "agent" "Cursor Agent" "https://cursor.com/install" "$HOME/.local/bin/agent")
+      # (mkCurlInstaller "agent" "Cursor Agent" "https://cursor.com/install" "$HOME/.local/bin/agent")
       # (mkCurlInstaller "vibe" "Mistral Vibe" "https://mistral.ai/vibe/install.sh" "$HOME/.local/bin/vibe")
       # (mkCurlInstaller "agy" "Antigravity CLI" "https://antigravity.google/cli/install.sh"
       #   "$HOME/.local/bin/agy"
@@ -153,7 +153,6 @@ in
       dust
       fd
       gnumake
-      go-task
       # pre-commit # requires swift, which is problematic and very expensive to build on macOS
       ripgrep
       ugrep

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -210,7 +210,6 @@ in
     home.file.".config/nvim-deps-path".text = lib.makeBinPath (
       with unstable;
       [
-        bun
         cmake
         beamPackages.elixir
         gcc

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -143,6 +143,7 @@ in
       # ========================================================================
       # Language-specific
       uv
+      unstable.deno # JS/TS runtime; also installs/runs the npm-managed CLI tools
 
       # Generic development
       bfs

--- a/nix/shared/home/package-tools.nix
+++ b/nix/shared/home/package-tools.nix
@@ -9,7 +9,6 @@
 #   - Each package installed globally via `deno install --global npm:<pkg>`
 #     (isolated in ~/.deno/)
 #   - Shims placed in ~/.deno/bin/ (added to PATH by this module)
-#   - macOS only for now (Linux support pending validation)
 #   - Upgrade: rebuild.sh --update-unstable or --update (runs the generated
 #     npm-tools-upgrade script)
 #
@@ -109,7 +108,6 @@ in
       default = [ ];
       description = ''
         npm packages to install globally via deno. Declarations merge across config levels.
-        macOS only for now (Linux support pending validation).
       '';
       example = [
         {
@@ -157,13 +155,13 @@ in
   };
 
   config = {
-    # Add deno's global shim directory to PATH (macOS only for now)
-    home.sessionPath = lib.optionals pkgs.stdenv.isDarwin [
+    # Add deno's global shim directory to PATH
+    home.sessionPath = [
       "$HOME/.deno/bin"
     ];
 
     # Upgrade helper invoked by rebuild.sh --update-unstable/--update
-    home.packages = lib.optionals (pkgs.stdenv.isDarwin && config.packageTools.npmPackages != [ ]) [
+    home.packages = lib.optionals (config.packageTools.npmPackages != [ ]) [
       npmUpgradeScript
     ];
 
@@ -173,11 +171,8 @@ in
       # --- uv tools (Python CLI tools, all platforms) ---
       ${uvToolInstallScript}
 
-      # --- npm tools via deno (macOS only for now) ---
-      CURRENT_PLATFORM="$(uname -s)"
-      if [[ "$CURRENT_PLATFORM" == "Darwin" ]]; then
-        ${npmInstallScript}
-      fi
+      # --- npm tools via deno (all platforms) ---
+      ${npmInstallScript}
     '';
   };
 }

--- a/nix/shared/home/package-tools.nix
+++ b/nix/shared/home/package-tools.nix
@@ -1,27 +1,29 @@
 # Package-managed CLI tools module
-# Handles installation of tools managed by bun (npm) and uv (Python).
+# Handles installation of tools managed by deno (npm) and uv (Python).
 #
 # Unlike self-managed CLIs (which install once and self-update), these tools
 # require explicit upgrades via rebuild.sh --update-unstable or --update.
 #
-# npm tools (bun):
+# npm tools (deno):
 #   - Declared via packageTools.npmPackages option (mergeable per-host/platform)
-#   - Each package installed globally via `bun install -g` (isolated in ~/.bun/)
-#   - Binaries symlinked to ~/.bun/bin/ (added to PATH by this module)
-#   - macOS only (npm binaries have dynamic linking issues on NixOS)
-#   - Upgrade: npm-tools/install.sh --upgrade (runs bun update -g)
+#   - Each package installed globally via `deno install --global npm:<pkg>`
+#     (isolated in ~/.deno/)
+#   - Shims placed in ~/.deno/bin/ (added to PATH by this module)
+#   - macOS only for now (Linux support pending validation)
+#   - Upgrade: rebuild.sh --update-unstable or --update (runs the generated
+#     npm-tools-upgrade script)
 #
 # Python tools (uv):
 #   - Declared via packageTools.uvTools option (mergeable per-host/platform)
 #   - Each tool gets its own isolated venv (managed by uv tool)
 #   - Binaries symlinked to ~/.local/bin/ (already on PATH)
-#   - Upgrade: uv-tools/install.sh --upgrade (runs uv tool upgrade --all)
+#   - Upgrade: rebuild.sh --update-unstable or --update (runs uv tool upgrade --all)
 #
 # Usage:
 #   # In any config level (common.nix, darwin.nix, host/users/user.nix):
 #   packageTools.npmPackages = [
-#     "@google/gemini-cli"
-#     "@openai/codex"
+#     { package = "@google/gemini-cli"; bin = "gemini"; }
+#     { package = "@openai/codex"; bin = "codex"; }
 #   ];
 #   packageTools.uvTools = [
 #     { package = "sqlit-tui"; }
@@ -38,16 +40,28 @@
 let
   unstable = inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system};
 
-  # Generate bun install -g commands from the merged npm packages option
-  npmInstallScript = lib.concatMapStringsSep "\n" (pkg: ''
-    if ${unstable.bun}/bin/bun pm bin -g &>/dev/null && \
-       [[ -f "$(${unstable.bun}/bin/bun pm bin -g)/${lib.last (lib.splitString "/" pkg)}" ]]; then
-      echo "Already installed: ${pkg}"
+  # Generate deno install commands from the merged npm packages option
+  npmInstallScript = lib.concatMapStringsSep "\n" (tool: ''
+    if [[ -f "$HOME/.deno/bin/${tool.bin}" ]]; then
+      echo "Already installed: ${tool.package}"
     else
-      echo "Installing ${pkg}..."
-      ${unstable.bun}/bin/bun install -g "${pkg}" || echo "Warning: Failed to install ${pkg}"
+      echo "Installing ${tool.package}..."
+      ${unstable.deno}/bin/deno install --global --allow-all --force \
+        --name "${tool.bin}" "npm:${tool.package}" \
+        || echo "Warning: Failed to install ${tool.package}"
     fi
   '') config.packageTools.npmPackages;
+
+  # Upgrade helper for rebuild.sh --update-unstable/--update: deno has no
+  # equivalent of `bun update -g`, so force-reinstall every declared package
+  # at its latest version (--reload bypasses the cached registry response).
+  npmUpgradeScript = pkgs.writeShellScriptBin "npm-tools-upgrade" (
+    lib.concatMapStringsSep "\n" (tool: ''
+      echo "Upgrading ${tool.package}..."
+      ${unstable.deno}/bin/deno install --global --allow-all --force --reload \
+        --name "${tool.bin}" "npm:${tool.package}"
+    '') config.packageTools.npmPackages
+  );
 
   # Generate uv tool install commands from the merged uv tools option
   uvToolInstallScript = lib.concatMapStringsSep "\n" (
@@ -73,15 +87,35 @@ in
 {
   options.packageTools = {
     npmPackages = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            package = lib.mkOption {
+              type = lib.types.str;
+              description = "npm package name (e.g., '@google/gemini-cli')";
+              example = "@google/gemini-cli";
+            };
+            bin = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                Executable name the package provides (its package.json "bin" entry).
+                Used to name the deno shim and to detect existing installs.
+              '';
+              example = "gemini";
+            };
+          };
+        }
+      );
       default = [ ];
       description = ''
-        npm packages to install globally via bun. Declarations merge across config levels.
-        macOS only (npm binaries have dynamic linking issues on NixOS).
+        npm packages to install globally via deno. Declarations merge across config levels.
+        macOS only for now (Linux support pending validation).
       '';
       example = [
-        "@google/gemini-cli"
-        "@openai/codex"
+        {
+          package = "@google/gemini-cli";
+          bin = "gemini";
+        }
       ];
       apply = lib.unique;
     };
@@ -123,10 +157,14 @@ in
   };
 
   config = {
-    # Add global bun bin directory to PATH (macOS only)
-    # Linux/NixOS: npm binaries have dynamic linking issues and won't run
+    # Add deno's global shim directory to PATH (macOS only for now)
     home.sessionPath = lib.optionals pkgs.stdenv.isDarwin [
-      "$HOME/.bun/bin"
+      "$HOME/.deno/bin"
+    ];
+
+    # Upgrade helper invoked by rebuild.sh --update-unstable/--update
+    home.packages = lib.optionals (pkgs.stdenv.isDarwin && config.packageTools.npmPackages != [ ]) [
+      npmUpgradeScript
     ];
 
     # Install package-managed tools on activation (install-if-missing, no upgrades)
@@ -135,7 +173,7 @@ in
       # --- uv tools (Python CLI tools, all platforms) ---
       ${uvToolInstallScript}
 
-      # --- npm tools via bun (macOS only) ---
+      # --- npm tools via deno (macOS only for now) ---
       CURRENT_PLATFORM="$(uname -s)"
       if [[ "$CURRENT_PLATFORM" == "Darwin" ]]; then
         ${npmInstallScript}

--- a/nvim-fredrik/plugin/code_runner.lua
+++ b/nvim-fredrik/plugin/code_runner.lua
@@ -8,7 +8,7 @@ require("lazyload").on_vim_enter(function()
     filetype = {
       elixir = { "elixir" },
       go = { "go run" },
-      typescript = { "bun" },
+      typescript = { "deno run -A" },
       zig = { "zig run" },
     },
   })

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -31,8 +31,8 @@ while [[ $# -gt 0 ]]; do
 		echo ""
 		echo "Options:"
 		echo "  --stow             Use Stow-only mode (bypass Nix, dotfiles only)"
-		echo "  --update           Update ALL flake inputs + uv tools + bun packages before rebuilding"
-		echo "  --update-unstable  Update unstable flake inputs + uv tools + bun packages before rebuilding"
+		echo "  --update           Update ALL flake inputs + uv tools + npm tools before rebuilding"
+		echo "  --update-unstable  Update unstable flake inputs + uv tools + npm tools before rebuilding"
 		echo "  --help             Show this help message"
 		exit 0
 		;;
@@ -93,7 +93,8 @@ use_nix() {
 		exit 1
 	fi
 
-	# Upgrade package-managed tools when updating (after rebuild so uv/bun are available)
+	# Upgrade package-managed tools when updating (after rebuild so the
+	# upgrade helpers are available)
 	if [[ "$UPDATE_FLAKE" == "true" || "$UPDATE_UNSTABLE" == "true" ]]; then
 		if command -v uv &>/dev/null; then
 			echo ""
@@ -101,10 +102,10 @@ use_nix() {
 			uv tool upgrade --all
 		fi
 
-		if command -v bun &>/dev/null; then
+		if command -v npm-tools-upgrade &>/dev/null; then
 			echo ""
-			echo "📦 Upgrading npm packages..."
-			bun update -g
+			echo "📦 Upgrading npm tools..."
+			npm-tools-upgrade
 		fi
 	fi
 

--- a/stow/shared/.claude/CLAUDE.md
+++ b/stow/shared/.claude/CLAUDE.md
@@ -118,10 +118,12 @@ reading the whole file.
 
 Use the "golang-style" skill.
 
-## Npm and bun
+## Npm and deno
 
-- Always prefer `bun` (or `bunx`) over `npm` (or `npmx`), unless the project
-  explicitly already uses Node/npm.
+- Always prefer `deno` over `npm`, unless the project explicitly already uses
+  Node/npm or Bun.
+- For one-off npm CLI runs, use `deno run -A npm:<pkg>` instead of `npx` or
+  `bunx`.
 
 ## Python
 

--- a/stow/shared/.config/opencode/opencode.jsonc
+++ b/stow/shared/.config/opencode/opencode.jsonc
@@ -116,7 +116,7 @@
     "playwright": {
       "enabled": false,
       "type": "local",
-      "command": ["bunx", "@playwright/mcp@latest"]
+      "command": ["deno", "run", "-A", "npm:@playwright/mcp@latest"]
     }
   }
 }

--- a/stow/shared/.config/opencode/opencode_work.jsonc
+++ b/stow/shared/.config/opencode/opencode_work.jsonc
@@ -91,7 +91,7 @@
     "playwright": {
       "enabled": false,
       "type": "local",
-      "command": ["bunx", "@playwright/mcp@latest"]
+      "command": ["deno", "run", "-A", "npm:@playwright/mcp@latest"]
     },
     "roadie-api-docs": {
       "enabled": false,

--- a/stow/shared/.copilot/mcp-config.json
+++ b/stow/shared/.copilot/mcp-config.json
@@ -13,18 +13,19 @@
       "tools": []
     },
     "context7": {
-      "command": "bunx",
+      "command": "deno",
       "args": [
-        "-y",
-        "@upstash/context7-mcp",
+        "run",
+        "-A",
+        "npm:@upstash/context7-mcp",
         "--api-key",
         "${CONTEXT7_API_KEY}"
       ],
       "tools": []
     },
     "playwright": {
-      "command": "bunx",
-      "args": ["@playwright/mcp@latest"],
+      "command": "deno",
+      "args": ["run", "-A", "npm:@playwright/mcp@latest"],
       "tools": []
     }
   }

--- a/stow/shared/.gemini/settings.json
+++ b/stow/shared/.gemini/settings.json
@@ -23,9 +23,11 @@
       "env": {}
     },
     "playwright": {
-      "command": "bunx",
+      "command": "deno",
       "args": [
-        "@playwright/mcp@latest"
+        "run",
+        "-A",
+        "npm:@playwright/mcp@latest"
       ]
     }
   },

--- a/stow/shared/.pi-work/agent/settings.json
+++ b/stow/shared/.pi-work/agent/settings.json
@@ -7,7 +7,7 @@
     "~/.claude-work/plugins/cache/*/*/*/commands/*.md"
   ],
   "npmCommand": [
-    "bun"
+    "npm"
   ],
   "packages": [
     "npm:pi-system-theme"

--- a/stow/shared/.pi/agent/settings.json
+++ b/stow/shared/.pi/agent/settings.json
@@ -7,7 +7,7 @@
     "~/.claude/plugins/cache/*/*/*/commands/*.md"
   ],
   "npmCommand": [
-    "bun"
+    "npm"
   ],
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.5",


### PR DESCRIPTION
## Why?

- Try deno as the JS runtime to play better with Nix: npm CLIs run inside deno's Node compat layer instead of as standalone node binaries, removing the dynamic-linking issue that kept `packageTools.npmPackages` macOS-only.
- Unlike bun/bunx, deno is now actually on PATH everywhere (`home.packages`), so MCP configs no longer depend on an environment that happens to provide the runner.

## What?

- `nix/shared/home/package-tools.nix`: install via `deno install --global --allow-all --name <bin> npm:<pkg>`; shims in `~/.deno/bin`
- `packageTools.npmPackages` entries are now `{ package, bin }` — shim names come from the package.json `bin` field and can't be derived (`@googleworkspace/cli` → `gws`); also fixes the install check, which looked for the wrong filename and reinstalled on every rebuild
- Render an `npm-tools-upgrade` script from the declared package list (deno has no `bun update -g`); `rebuild.sh --update/--update-unstable` calls it
- Drop the Darwin-only guards so npm tools install on Linux/NixOS too
- Stow configs: `bunx` → `deno run -A npm:<pkg>` (gemini, copilot, opencode); code_runner runs TS via `deno run -A`; pi `npmCommand` → `npm` (deno is not argv-compatible with the npm CLI)
- Evict remaining bun: dev shell, nvim-deps PATH, stale `npm-tools/` gitignore entry; docs updated

```nix
packageTools.npmPackages = [
  { package = "@google/gemini-cli"; bin = "gemini"; }
];
```

## Notes

- No nix in the dev container — relying on CI + a local `./rebuild.sh` on a Mac to validate that `gemini`, `codex` and `pi` actually work under deno's Node compat. Test on rpi5-homelab before declaring npm tools in Linux configs; revert the "enable on Linux" commit if they misbehave there.
- Deno shims hardcode the Nix store path of the deno that installed them: after a GC that removes an old generation, a shim can go stale while the presence check still says "already installed". Re-running `npm-tools-upgrade` re-creates the shims.
- pi's `npmCommand: ["npm"]` relies on npm from nodejs (nvim-deps PATH) — the same availability domain bun had, but worth a sanity check in a pi session.
- Playwright MCP under deno may need `PLAYWRIGHT_BROWSERS_PATH` verified when it downloads/locates browsers.
