### PR TITLE
feat(nix): install LLM agent CLIs via numtide/llm-agents.nix flake input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,11 @@ and **GNU Stow** for dotfile symlinking.
 - **Self-managed CLIs**: Tools with native installers that auto-update (e.g.,
   Claude Code) are declared in `selfManagedCLIs` lists at any config level
   (common, platform-specific, or user-specific)
+- **LLM agent CLIs**: Packaged agents (codex, gemini-cli, pi, ...) come from
+  the `llm-agents` flake input (numtide/llm-agents.nix) and are added to
+  `home.packages` in `nix/shared/home/common.nix`. Do not make this input
+  follow another nixpkgs — it is built/cached against its own pin
+  (cache.numtide.com). Update via `./rebuild.sh --update-unstable`
 
 ### Self-Managed CLIs
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,11 @@
   nixConfig = {
     extra-substituters = [
       "https://nixos-raspberrypi.cachix.org"
+      "https://cache.numtide.com"
     ];
     extra-trusted-public-keys = [
       "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
     ];
   };
 
@@ -56,6 +58,11 @@
       url = "github:nix-community/home-manager/master";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
+    # AI coding agent CLIs (codex, gemini-cli, pi, ...), updated daily upstream.
+    # NOTE: Do NOT make this follow another nixpkgs: packages are built and
+    # cached against its own pinned nixpkgs-unstable, and cache.numtide.com
+    # only serves those builds.
+    llm-agents.url = "github:numtide/llm-agents.nix";
     dotfiles = {
       # Used by home-manager for dotfiles bootstrapping.
       url = "github:fredrikaverpil/dotfiles";

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -8,6 +8,7 @@
 }:
 let
   unstable = inputs.nixpkgs-unstable.legacyPackages.${pkgs.stdenv.hostPlatform.system};
+  llmAgents = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
 
   # Bob's neovim proxy (~/.local/share/bob/nvim-bin/nvim) is a copy of the bob
   # binary and inherits its permissions. The Nix-store bob is read-only, so the
@@ -54,11 +55,7 @@ in
     ];
 
     # npm packages via bun (macOS only, mergeable across config levels)
-    packageTools.npmPackages = [
-      "@google/gemini-cli"
-      "@openai/codex"
-      "@earendil-works/pi-coding-agent"
-    ];
+    packageTools.npmPackages = [ ];
 
     # Python CLI tools via uv (mergeable across config levels)
     packageTools.uvTools = [
@@ -187,6 +184,12 @@ in
       llama-cpp
       slides
       chafa # Required for showing images in slides
+
+      # AI coding agents from the llm-agents flake input (see flake.nix).
+      # Update via `./rebuild.sh --update-unstable` (or --update).
+      llmAgents.codex # @openai/codex
+      llmAgents.gemini-cli # @google/gemini-cli
+      llmAgents.pi # @earendil-works/pi-coding-agent
 
       # ========================================================================
       # Infrastructure & Cloud

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -65,7 +65,7 @@ use_nix() {
 	# Update only unstable inputs if requested
 	elif [[ "$UPDATE_UNSTABLE" == "true" ]]; then
 		echo "🔄 Updating unstable inputs..."
-		nix flake update nixpkgs-unstable nix-darwin home-manager-unstable dotfiles
+		nix flake update nixpkgs-unstable nix-darwin home-manager-unstable llm-agents dotfiles
 		echo "✅ Unstable inputs updated!"
 	fi
 


### PR DESCRIPTION
## What

Replaces the bun-managed installs of the LLM agent CLIs with Nix packages from [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix) (formerly `nix-ai-tools`; ~1.6k stars, 100+ agents packaged, auto-updated daily, prebuilt binaries via `cache.numtide.com`). Alternatives considered — the forks (e.g. Qumulo/llm-agents) and single-tool flakes (e.g. sadjow/claude-code-nix) are all smaller; this is the de-facto standard flake for AI coding agents.

| Before (bun, macOS-only) | After (llm-agents flake input) |
|---|---|
| `@openai/codex` | `codex` |
| `@google/gemini-cli` | `gemini-cli` |
| `@earendil-works/pi-coding-agent` | `pi` |

## Changes

- **flake.nix**: new `llm-agents` input, plus `cache.numtide.com` substituter + trusted key in `nixConfig`. Deliberately **no** `nixpkgs.follows` — upstream builds/caches against its own pinned nixpkgs-unstable, and a `follows` would forfeit binary cache hits (same reasoning as the `nixos-raspberrypi` pin).
- **nix/shared/home/common.nix**: `codex`, `gemini-cli` and `pi` added to `home.packages`; the three npm packages removed from `packageTools.npmPackages`.
- **rebuild.sh**: `llm-agents` added to the `--update-unstable` input set (matches its daily release cadence).
- **CLAUDE.md**: documents the new mechanism.

The bun/uv `packageTools` mechanism is untouched and still used for non-agent tools (`@googleworkspace/cli` on zap/plumbus, `sqlit-tui` via uv).

## Behavior change

The agents were previously macOS-only (bun dynamic-linking issues on NixOS). As Nix packages they now install on **all** hosts, including `rpi5-homelab`. If you don't want them on the Pi, move the three entries from `common.nix` to `nix/shared/home/darwin.nix`'s `home.packages`.

## Manual follow-ups after merge

1. **Lock the input**: `flake.lock` has no `llm-agents` entry yet. Run `nix flake lock` and commit (or let the first rebuild write it). CI's `nix flake check` locks it on the fly, so the PR is still validated.
2. **Remove the stale bun copies** on macOS hosts, otherwise `bun update -g` keeps upgrading them alongside the Nix ones:
   ```sh
   bun remove -g @google/gemini-cli @openai/codex @earendil-works/pi-coding-agent
   ```
3. First rebuild may prompt about the new substituter unless your user is in `trusted-users` (same note as the existing cachix one at the top of flake.nix).