### PR TITLE
fix(claude): apply sandbox git identity globally, not per-repo

### DIFF
--- a/.claude/hooks/sandbox-git-identity.sh
+++ b/.claude/hooks/sandbox-git-identity.sh
@@ -4,13 +4,15 @@ set -e
 
 # In the Claude Code cloud sandbox, commits would otherwise be authored as
 # Claude and signed with Claude's key. Override with my identity and disable
-# signing (no private key exists in the sandbox). On a developer machine the
-# stowed ~/.gitconfig already handles identity and signing, so do nothing.
+# signing (no private key exists in the sandbox). Use global config: the
+# sandbox is ephemeral and may hold multiple repos (CLAUDE_PROJECT_DIR is
+# unset in multi-repo sessions), so this covers every repo in the session,
+# including ones added mid-session. On a developer machine the stowed
+# ~/.gitconfig already handles identity and signing, so do nothing.
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-cd "${CLAUDE_PROJECT_DIR:?}"
-git config user.name "Fredrik Averpil"
-git config user.email "fredrik.averpil@proton.me"
-git config commit.gpgsign false
+git config --global user.name "Fredrik Averpil"
+git config --global user.email "fredrik.averpil@proton.me"
+git config --global commit.gpgsign false


### PR DESCRIPTION
## Why?

- The SessionStart hook crashed in multi-repo cloud sandbox sessions: `CLAUDE_PROJECT_DIR` is unset there, and with `set -e` the hook died before writing any config:

  ```bash
  cd "${CLAUDE_PROJECT_DIR:?}"  # parameter null or not set → hook exits
  ```

- Result: no identity override at all — commits in every repo, including this one, would be authored as Claude (noreply@anthropic.com) and signed with Claude's key.
- Even when `CLAUDE_PROJECT_DIR` is set, `--local` config only covers the repo that registered the hook; sibling repos in the session keep Claude's identity.

## What?

- Write identity and signing config with `git config --global` instead of `--local` ([sandbox-git-identity.sh:16](https://github.com/fredrikaverpil/dotfiles/blob/285e91d1f97508e8ebc324258e16184ea8a2d0f7/.claude/hooks/sandbox-git-identity.sh#L16))
- Drop the `cd "${CLAUDE_PROJECT_DIR:?}"` dependency entirely
- Sandbox is ephemeral and single-user, so global config safely covers every repo in the session, including repos added mid-session
- `CLAUDE_CODE_REMOTE` guard unchanged — developer machines are untouched

## Notes

- Verified in a live multi-repo sandbox session (dotfiles + openfga): hook exits cleanly, `git config user.email` resolves to my identity inside the sibling repo, and the commit on this PR is authored accordingly
- Known limitation: sandbox sessions that don't include this repo get no hook at all; that can only be addressed at the environment level, not in a repo