### PR TITLE
feat(claude): expose more skills to cloud sandbox sessions

### DIFF
--- a/.claude/skills/aip
+++ b/.claude/skills/aip
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/aip

--- a/.claude/skills/codebase-audit
+++ b/.claude/skills/codebase-audit
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/codebase-audit

--- a/.claude/skills/golang-style
+++ b/.claude/skills/golang-style
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/golang-style

--- a/.claude/skills/nvim-config
+++ b/.claude/skills/nvim-config
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/nvim-config

--- a/.claude/skills/nvim-plugin
+++ b/.claude/skills/nvim-plugin
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/nvim-plugin

--- a/.claude/skills/proof
+++ b/.claude/skills/proof
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/proof

--- a/.claude/skills/self-review
+++ b/.claude/skills/self-review
@@ -1,0 +1,1 @@
+../../stow/shared/.claude/skills/self-review


### PR DESCRIPTION
Symlink golang-style, self-review, codebase-audit, aip, proof,
nvim-config and nvim-plugin from the stowed personal skills into the
repo-root .claude folder, alongside the existing git-commit and
pr-style links.

The repo-root folder is what cloud sandbox sessions load, so it is
curated deliberately rather than symlinking the whole skills folder:
machine-bound skills (neovim RPC, obsidian vault, gh CLI) would
mis-trigger or steer toward tools that do not exist in the sandbox,
and new skills should opt in per audience rather than auto-expose.