### PR TITLE
feat(claude): install Neovim in the web sandbox to test config changes

### DIFF
--- a/stow/shared/.claude-web/skills/neovim
+++ b/stow/shared/.claude-web/skills/neovim
@@ -1,0 +1,1 @@
+../../.claude/skills/neovim

--- a/stow/shared/.claude-web/skills/nix-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nix-install/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: nix-install
+description: Install Nix in the Claude Code web sandbox (the cloud environment) as a general-purpose package installer, then install packages from the Nix binary cache with no GitHub access. Use whenever a web session needs a tool that isn't preinstalled and isn't in a language registry (npm/pypi/crates/go) — Neovim, ripgrep, a compiler, anything in nixpkgs. Installs nix-bin via apt, configures single-user mode, and installs packages via nix-env against the nixpkgs channel tarball. Web-sandbox only.
+---
+
+# Install Nix in the web sandbox
+
+Nix is the most general way to install tools in the Claude Code web sandbox. The
+sandbox network is locked to package registries plus this session's GitHub
+repos, but two facts make Nix work anyway:
+
+- `apt` reaches the main Ubuntu archive, and **`nix-bin` is in it**.
+- `cache.nixos.org` and `channels.nixos.org` are reachable through the proxy, so
+  Nix substitutes prebuilt binaries and pulls the nixpkgs expression **without
+  any GitHub access**.
+
+**Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). On a real machine Nix
+is already the system package manager — do not run this there.
+
+## Step 0 — Verify the network path (usually already open)
+
+```bash
+curl -sSI -o /dev/null -w "cache:    %{http_code}\n" https://cache.nixos.org
+curl -sSI -o /dev/null -w "channels: %{http_code}\n" https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+```
+
+`200`/`302` on both → proceed. If either is blocked, the environment's network
+policy is stricter than default; widen it (claude.ai environment editor →
+network / allowed hosts) to include `cache.nixos.org` and `channels.nixos.org`.
+
+## Step 1 — Install Nix (via apt)
+
+The Claude Code web docs recommend refreshing the apt index first; do that, then
+install `nix-bin`:
+
+```bash
+apt-get update
+apt-get install -y --no-install-recommends nix-bin
+# Single-user (rootless-build) mode: the sandbox has no 'nixbld' build-users
+# group, so disable multi-user builds or nix-env operations fail.
+mkdir -p /etc/nix
+grep -q '^build-users-group' /etc/nix/nix.conf 2>/dev/null \
+  || echo 'build-users-group =' >> /etc/nix/nix.conf
+nix --version
+```
+
+## Step 2 — Install packages
+
+Use classic `nix-env` against the channel tarball. **Do not** use flakes / `nix
+run nixpkgs#pkg` here: the `nixpkgs` flake reference resolves to
+github.com/NixOS/nixpkgs, which the proxy blocks. The channel tarball is served
+from the reachable `channels.nixos.org`, so this needs no GitHub:
+
+```bash
+TARBALL=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+nix-env -iA ripgrep -f "$TARBALL"     # attribute name = nixpkgs attr path
+export PATH="$HOME/.nix-profile/bin:$PATH"
+rg --version
+```
+
+Finding an attribute name quickly — query the single attribute, not all of
+nixpkgs (a bare `nix-env -qaP` evaluates everything and is very slow):
+
+```bash
+nix-env -f "$TARBALL" -qaP -A ripgrep   # -> "ripgrep  ripgrep-14.x"
+```
+
+## Persisting the environment
+
+The sandbox runs each command in a fresh shell initialized from your profile, so
+a plain `export PATH=...` does not survive to the next Bash call. Persist it:
+
+```bash
+grep -qxF 'export PATH="$HOME/.nix-profile/bin:$PATH"' ~/.bashrc 2>/dev/null \
+  || echo 'export PATH="$HOME/.nix-profile/bin:$PATH"' >> ~/.bashrc
+```
+
+## Caveats
+
+- **Ephemeral.** The install lives only for this environment's lifetime; nothing
+  is committed. Re-run in a fresh environment.
+- **`nixpkgs-unstable` is a moving target.** The version you get today may differ
+  tomorrow. Pin a specific channel (e.g. a `nixos-XX.YY` tarball URL) if you need
+  reproducibility.
+- **GitHub-sourced packages still need GitHub.** Anything Nix fetches from
+  github.com at build time (flake inputs, `fetchFromGitHub` on a cache miss) is
+  subject to the proxy's GitHub scoping. Prebuilt substitutes from
+  `cache.nixos.org` avoid this for anything already cached — which is the common
+  case for nixpkgs packages.

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvim-install
-description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs Nix via apt and a vim.pack-capable Neovim (0.12.x) from the Nix binary cache with no GitHub access, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only.
+description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs bob via Nix and a stable/nightly Neovim via bob, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only.
 ---
 
 # Install Neovim in the web sandbox
@@ -13,72 +13,66 @@ editor. This skill installs the binary, launches Neovim **headless** with a
 listen socket, and exports `$NVIM` so every command in the `neovim` skill works
 verbatim afterwards.
 
+Neovim is installed with **bob** — the same version manager used on the real
+machines, so stable/nightly is a one-word switch — and bob itself is installed
+with **Nix**.
+
 **Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). Do not run on a real
-machine — there Neovim is managed by bob at `~/.local/share/bob/nvim-bin/nvim`.
-
-## The install path: Nix (verified best for the sandbox)
-
-The sandbox network is locked to package registries plus this session's GitHub
-repos. Two facts make **Nix** the cleanest binary source, better than bob or a
-GitHub tarball:
-
-- `apt` reaches the main Ubuntu archive, and **`nix-bin` is in it**.
-- `cache.nixos.org` and `channels.nixos.org` are reachable through the proxy,
-  so Nix substitutes prebuilt binaries **without any GitHub access**.
-- `nixpkgs-unstable` currently ships **Neovim 0.12.x**, which has both
-  `vim.pack` and `vim._core.ui2` — exactly what `nvim-fredrik` requires. (bob
-  and a nightly tarball both need GitHub even to fetch the binary; Nix does
-  not.)
+machine — there bob already manages Neovim at
+`~/.local/share/bob/nvim-bin/nvim`.
 
 ## Step 0 — Network prerequisites
 
 Two independent needs, in order of when they bite:
 
-1. **The binary (this skill):** the Ubuntu archive, `channels.nixos.org`, and
-   `cache.nixos.org`. These are reachable in the default sandbox policy — no
-   action normally needed. Verify:
+1. **bob + the Neovim binary:** bob is installed from the Nix cache (no GitHub),
+   but bob then downloads Neovim from **github.com/neovim/neovim**. In the
+   sandbox, GitHub is gated by the proxy to this session's repo scope, so bob's
+   download is denied until `neovim/neovim` is in scope. Enable it with
+   `add_repo neovim/neovim` (ask Claude: *"add the neovim/neovim repo"* — Claude
+   only runs `add_repo` when you ask), or widen the environment network policy
+   to allow `github.com` / `api.github.com` / `objects.githubusercontent.com`.
+2. **The plugins (to actually run `nvim-fredrik`):** at startup `vim.pack` clones
+   ~50 plugins from **github.com** and **codeberg.org**. Both are blocked by
+   default (`403`), so the config installs and *starts* but plugin cloning fails
+   until the environment network policy allows those hosts. This is an
+   environment-config change (claude.ai environment editor → network / allowed
+   hosts: add `github.com` and `codeberg.org`), then rebuild. See
+   https://code.claude.com/docs/en/claude-code-on-the-web.
 
-   ```bash
-   curl -sSI -o /dev/null -w "cache:    %{http_code}\n" https://cache.nixos.org
-   curl -sSI -o /dev/null -w "channels: %{http_code}\n" https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
-   ```
+Widening the network policy to allow `github.com` satisfies both at once, which
+is the simplest route to a full config run.
 
-   `200`/`302` → good.
+## Step 1 — Ensure Nix is installed
 
-2. **The plugins (to actually run `nvim-fredrik`):** at startup `vim.pack`
-   clones ~50 plugins from **github.com** and **codeberg.org**. Both are
-   **blocked by default** (`403` through the proxy), so the config installs the
-   binary and *starts*, but plugin cloning fails until the environment's network
-   policy allows those hosts. This is an environment-config change (claude.ai
-   environment editor → network / allowed hosts; add `github.com` and
-   `codeberg.org`), then rebuild the environment. See
-   https://code.claude.com/docs/en/claude-code-on-the-web. Nothing in the repo
-   can route around it — the binary can be installed without it, but a full
-   plugin sync cannot.
-
-## Step 1 — Install Nix (via apt)
+Follow the **`nix-install`** skill (apt `nix-bin` + single-user config). In
+short:
 
 ```bash
-apt-get update -qq
+apt-get update
 apt-get install -y --no-install-recommends nix-bin
-# Single-user (rootless-build) mode: no nixbld group exists in the sandbox.
 mkdir -p /etc/nix
 grep -q '^build-users-group' /etc/nix/nix.conf 2>/dev/null \
   || echo 'build-users-group =' >> /etc/nix/nix.conf
-nix --version
 ```
 
-## Step 2 — Install Neovim from nixpkgs-unstable
+## Step 2 — Install bob via Nix, then Neovim via bob
 
-`nvim-fredrik` requires `vim.pack` and `vim._core.ui2`, which land in Neovim
-0.12.x — provided by `nixpkgs-unstable`. Everything is substituted from
-`cache.nixos.org`; nothing is compiled and no GitHub is touched.
+The nixpkgs attribute is `bob-nvim` (the binary is `bob`), substituted from the
+cache with no GitHub. Then bob installs Neovim (needs Step 0 item 1).
+`nvim-fredrik` requires **nightly** (`vim.pack` + `vim._core.ui2`); for other
+configs swap `nightly` for `stable` or a version like `v0.11.0`.
 
 ```bash
-nix-env -iA neovim -f https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+TARBALL=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+nix-env -iA bob-nvim -f "$TARBALL"
 export PATH="$HOME/.nix-profile/bin:$PATH"
-nvim --version | head -1                       # expect NVIM v0.12.x
-nvim --headless -c 'lua io.write(tostring(vim.pack ~= nil))' -c 'qa'   # expect: true
+bob --version
+
+bob use nightly     # installs if missing, then makes it the active version
+export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
+nvim --version | head -1                                              # NVIM v0.12.x
+nvim --headless -c 'lua io.write(tostring(vim.pack ~= nil))' -c 'qa'  # expect: true
 ```
 
 ## Step 3 — Wire the config into place and persist the environment
@@ -99,7 +93,7 @@ mkdir -p ~/.config
 ln -sfn "$repo/nvim-fredrik" ~/.config/nvim-fredrik
 
 cat > ~/.nvim-sandbox.env <<EOF
-export PATH="\$HOME/.nix-profile/bin:\$PATH"
+export PATH="\$HOME/.nix-profile/bin:\$HOME/.local/share/bob/nvim-bin:\$PATH"
 export DOTFILES="$repo"
 export NVIM_APPNAME=nvim-fredrik
 export NVIM=/tmp/nvim-fredrik.sock
@@ -114,8 +108,8 @@ source ~/.nvim-sandbox.env
 This is the bridge to the `neovim` skill. Start a backgrounded headless
 instance listening on `$NVIM` (persisted in Step 3), so the RPC skill's
 commands — which all key off `$NVIM` — work unchanged. The **first** launch
-clones all plugins via `vim.pack` (needs the Step 0 plugin-network access) and
-can take a few minutes.
+clones all plugins via `vim.pack` (needs Step 0 item 2) and can take a few
+minutes.
 
 ```bash
 rm -f "$NVIM"
@@ -130,7 +124,7 @@ echo "NVIM socket: $NVIM"; tail -8 /tmp/nvim-headless.log
 ```
 
 `403` / `CONNECT tunnel failed` lines in the log mean github.com/codeberg.org
-are still not allowed (back to Step 0, item 2). The editor still runs; only the
+are still not allowed (back to Step 0 item 2). The editor still runs; only the
 plugins that failed to clone are missing.
 
 ## Step 5 — Verify and hand off to the `neovim` skill
@@ -143,7 +137,7 @@ nvim --server "$NVIM" --remote-expr 'luaeval("vim.fn.stdpath(\"config\")")'
 `$NVIM` is now set exactly as if Claude Code were running inside a Neovim
 terminal, so **switch to the `neovim` skill** for all further interaction
 (buffer state, running Lua, inspecting diagnostics, LSP, plugins). Note: the
-`neovim` skill's `NVIM_APPNAME` stdout-warning filter is aimed at the dotfiles
+`neovim` skill's `NVIM_APPNAME` stdout-warning filter targets the dotfiles
 `nvim` wrapper; here you invoke the real binary directly, so the warning usually
 does not appear — the filter is harmless either way.
 
@@ -177,21 +171,19 @@ diagnostics:
 nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")'
 ```
 
-## Alternatives to the Nix path
+## Alternative: Neovim directly via Nix (no GitHub for the binary)
 
-- **bob** (matches the real machines, one-word stable/nightly): the Rust
-  toolchain is preinstalled, so `cargo install bob-nvim` works with no GitHub.
-  But `bob install nightly` downloads Neovim from **github.com/neovim/neovim**,
-  which the proxy gates to the session's repo scope — enable it with
-  `add_repo neovim/neovim` (ask Claude) or by widening the network policy. Then
-  `bob use nightly` puts the binary at `~/.local/share/bob/nvim-bin/nvim`.
-- **Direct tarball** (no Rust): `curl -fL
-  https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-$(uname -m).tar.gz
-  | tar -xz -C /opt/nvim --strip-components=1` — same GitHub-access prerequisite
-  as bob.
+If you only need a modern Neovim and don't want to allowlist GitHub for the
+binary, skip bob — `nixpkgs-unstable` currently ships Neovim 0.12.x (which has
+`vim.pack` and `vim._core.ui2`), substituted straight from the cache:
 
-Both alternatives still hit the Step 0 plugin-network requirement for a full
-`nvim-fredrik` run; only the binary source differs.
+```bash
+nix-env -iA neovim -f https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+export PATH="$HOME/.nix-profile/bin:$PATH"
+```
+
+Update Step 3's persisted `PATH` to drop the bob path if you use this. The
+plugin-network prerequisite (Step 0 item 2) still applies to a full config run.
 
 ## Caveats
 

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -45,10 +45,14 @@ Two independent mechanisms gate traffic; they bite at different points.
      (`github.com` is allow-listed). No action.
    - **codeberg.org plugins** (nvim-lint, nvim-dap, nvim-dap-python) —
      **required and blocked by default.** Edit the environment → **Network
-     access** selector → **Custom** → in **Allowed domains** add `codeberg.org`
-     → tick *"Also include default list of common package managers"* → save.
-     This rebuilds the environment. See
-     https://code.claude.com/docs/en/claude-code-on-the-web.
+     access** selector → **Custom** → in **Allowed domains** add the bare
+     `codeberg.org` → tick *"Also include default list of common package
+     managers"* → save. This rebuilds the environment. See
+     https://code.claude.com/docs/en/claude-code-on-the-web. **Gotcha:** use the
+     apex `codeberg.org`, not `*.codeberg.org` — the wildcard matches only
+     subdomains, but the plugin `src` URLs are `https://codeberg.org/...`, so a
+     `*.codeberg.org`-only allowlist still 403s the clones. (`Full` network
+     access also works but is broader than needed.)
    - **GitHub release assets** (codediff's prebuilt lib, Mason LSP servers,
      treesitter parsers) — gated by the GitHub proxy to *attached* repos
      **regardless of network level**, so they may 403. Optional for observing

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvim-install
-description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs bob via Nix and a stable/nightly Neovim via bob, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only.
+description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs Neovim via Nix from the binary cache with no GitHub access, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only.
 ---
 
 # Install Neovim in the web sandbox
@@ -13,35 +13,47 @@ editor. This skill installs the binary, launches Neovim **headless** with a
 listen socket, and exports `$NVIM` so every command in the `neovim` skill works
 verbatim afterwards.
 
-Neovim is installed with **bob** — the same version manager used on the real
-machines, so stable/nightly is a one-word switch — and bob itself is installed
-with **Nix**.
-
 **Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). Do not run on a real
-machine — there bob already manages Neovim at
-`~/.local/share/bob/nvim-bin/nvim`.
+machine — there Neovim is managed by bob at `~/.local/share/bob/nvim-bin/nvim`.
+
+## Why Nix, not bob
+
+Nix installs Neovim from `*.nixos.org` (allow-listed by default), so the binary
+needs **no GitHub access** — and `nixpkgs-unstable` ships Neovim 0.12.x, which
+has both `vim.pack` and `vim._core.ui2`, exactly what `nvim-fredrik` requires.
+bob is available too (see the end), but `bob install` downloads Neovim as a
+**GitHub release asset**, which the GitHub proxy blocks unless `neovim/neovim`
+is attached to the session — regardless of network level. So Nix is the default;
+bob is an opt-in.
 
 ## Step 0 — Network prerequisites
 
-Two independent needs, in order of when they bite:
+Two independent mechanisms gate traffic; they bite at different points.
 
-1. **bob + the Neovim binary:** bob is installed from the Nix cache (no GitHub),
-   but bob then downloads Neovim from **github.com/neovim/neovim**. In the
-   sandbox, GitHub is gated by the proxy to this session's repo scope, so bob's
-   download is denied until `neovim/neovim` is in scope. Enable it with
-   `add_repo neovim/neovim` (ask Claude: *"add the neovim/neovim repo"* — Claude
-   only runs `add_repo` when you ask), or widen the environment network policy
-   to allow `github.com` / `api.github.com` / `objects.githubusercontent.com`.
-2. **The plugins (to actually run `nvim-fredrik`):** at startup `vim.pack` clones
-   ~50 plugins from **github.com** and **codeberg.org**. Both are blocked by
-   default (`403`), so the config installs and *starts* but plugin cloning fails
-   until the environment network policy allows those hosts. This is an
-   environment-config change (claude.ai environment editor → network / allowed
-   hosts: add `github.com` and `codeberg.org`), then rebuild. See
-   https://code.claude.com/docs/en/claude-code-on-the-web.
+1. **The binary (this skill):** substituted from the Nix cache (`*.nixos.org`),
+   reachable under the default **Trusted** network policy. No GitHub, no action.
+   Verify:
 
-Widening the network policy to allow `github.com` satisfies both at once, which
-is the simplest route to a full config run.
+   ```bash
+   curl -sSI -o /dev/null -w "cache:    %{http_code}\n" https://cache.nixos.org
+   curl -sSI -o /dev/null -w "channels: %{http_code}\n" https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+   ```
+
+2. **The plugins (a full `nvim-fredrik` run):** at startup `vim.pack` clones ~50
+   plugins. These split three ways:
+   - **Public GitHub clones** — already work under the default Trusted policy
+     (`github.com` is allow-listed). No action.
+   - **codeberg.org plugins** (nvim-lint, nvim-dap, nvim-dap-python) —
+     **required and blocked by default.** Edit the environment → **Network
+     access** selector → **Custom** → in **Allowed domains** add `codeberg.org`
+     → tick *"Also include default list of common package managers"* → save.
+     This rebuilds the environment. See
+     https://code.claude.com/docs/en/claude-code-on-the-web.
+   - **GitHub release assets** (codediff's prebuilt lib, Mason LSP servers,
+     treesitter parsers) — gated by the GitHub proxy to *attached* repos
+     **regardless of network level**, so they may 403. Optional for observing
+     most config behavior; attach a specific repo with `add_repo` only if the
+     change under test needs it.
 
 ## Step 1 — Ensure Nix is installed
 
@@ -56,21 +68,14 @@ grep -q '^build-users-group' /etc/nix/nix.conf 2>/dev/null \
   || echo 'build-users-group =' >> /etc/nix/nix.conf
 ```
 
-## Step 2 — Install bob via Nix, then Neovim via bob
+## Step 2 — Install Neovim from nixpkgs-unstable
 
-The nixpkgs attribute is `bob-nvim` (the binary is `bob`), substituted from the
-cache with no GitHub. Then bob installs Neovim (needs Step 0 item 1).
-`nvim-fredrik` requires **nightly** (`vim.pack` + `vim._core.ui2`); for other
-configs swap `nightly` for `stable` or a version like `v0.11.0`.
+Everything is substituted from `cache.nixos.org`; nothing is compiled and no
+GitHub is touched.
 
 ```bash
-TARBALL=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
-nix-env -iA bob-nvim -f "$TARBALL"
+nix-env -iA neovim -f https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
 export PATH="$HOME/.nix-profile/bin:$PATH"
-bob --version
-
-bob use nightly     # installs if missing, then makes it the active version
-export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
 nvim --version | head -1                                              # NVIM v0.12.x
 nvim --headless -c 'lua io.write(tostring(vim.pack ~= nil))' -c 'qa'  # expect: true
 ```
@@ -93,7 +98,7 @@ mkdir -p ~/.config
 ln -sfn "$repo/nvim-fredrik" ~/.config/nvim-fredrik
 
 cat > ~/.nvim-sandbox.env <<EOF
-export PATH="\$HOME/.nix-profile/bin:\$HOME/.local/share/bob/nvim-bin:\$PATH"
+export PATH="\$HOME/.nix-profile/bin:\$PATH"
 export DOTFILES="$repo"
 export NVIM_APPNAME=nvim-fredrik
 export NVIM=/tmp/nvim-fredrik.sock
@@ -123,9 +128,10 @@ done
 echo "NVIM socket: $NVIM"; tail -8 /tmp/nvim-headless.log
 ```
 
-`403` / `CONNECT tunnel failed` lines in the log mean github.com/codeberg.org
-are still not allowed (back to Step 0 item 2). The editor still runs; only the
-plugins that failed to clone are missing.
+`403` / `CONNECT tunnel failed` lines in the log point at the Step 0 item 2
+gaps (usually `codeberg.org` if it isn't allowed yet, or a GitHub release
+asset). The editor still runs; only the plugins that failed to clone are
+missing.
 
 ## Step 5 — Verify and hand off to the `neovim` skill
 
@@ -171,27 +177,34 @@ diagnostics:
 nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")'
 ```
 
-## Alternative: Neovim directly via Nix (no GitHub for the binary)
+## Optional: bob for explicit stable/nightly management
 
-If you only need a modern Neovim and don't want to allowlist GitHub for the
-binary, skip bob — `nixpkgs-unstable` currently ships Neovim 0.12.x (which has
-`vim.pack` and `vim._core.ui2`), substituted straight from the cache:
+If you specifically want a bob-managed version (one-word stable/nightly switch,
+matching the real machines), install bob from Nix and let it fetch Neovim — but
+note bob's download is a GitHub **release asset**, so `neovim/neovim` must be
+attached to the session first (`add_repo neovim/neovim`; Claude only runs it
+when you ask). Network level alone will not unblock it.
 
 ```bash
-nix-env -iA neovim -f https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+TARBALL=https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+nix-env -iA bob-nvim -f "$TARBALL"          # the binary is `bob`
 export PATH="$HOME/.nix-profile/bin:$PATH"
+bob use nightly                              # needs neovim/neovim attached
+export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
 ```
 
-Update Step 3's persisted `PATH` to drop the bob path if you use this. The
-plugin-network prerequisite (Step 0 item 2) still applies to a full config run.
+If you use this, add `$HOME/.local/share/bob/nvim-bin` to the persisted `PATH`
+in Step 3. For most sandbox testing the Step 2 Nix binary is simpler and needs
+no attachment.
 
 ## Caveats
 
 - **First launch is slow** — plugin cloning is network-bound and serial.
 - **Mason / LSP servers and treesitter parsers are best-effort.** They pull
-  extra tools from GitHub and compile locally; if a change under test doesn't
-  depend on a language server, you don't need them. Failures are logged in
-  `/tmp/nvim-headless.log` and don't prevent the rest of the config loading.
+  extra tools from GitHub release assets and compile locally; if a change under
+  test doesn't depend on a language server, you don't need them. Failures are
+  logged in `/tmp/nvim-headless.log` and don't prevent the rest of the config
+  loading.
 - **Headless has no UI.** Inspect state via RPC (`vim.diagnostic.get`,
   `vim.lsp.get_clients`, buffer APIs), not by looking at a screen.
 - **Ephemeral.** The install and config live only for this environment's

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: nvim-install
+description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Downloads the nightly Neovim tarball, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only; on a real machine Neovim is managed by Bob.
+---
+
+# Install Neovim in the web sandbox
+
+This skill bootstraps a real, running Neovim in the Claude Code web sandbox so
+that config changes (e.g. a PR against `nvim-fredrik`) can be exercised and
+observed. It is the missing half of the `neovim` RPC skill: that skill assumes
+a running Neovim exposed via `$NVIM`, but the sandbox has neither the binary
+nor a parent editor. This skill installs the binary, launches Neovim
+**headless** with a listen socket, and exports `$NVIM` so every command in the
+`neovim` skill works verbatim afterwards.
+
+**Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). Do not run on a real
+machine — there Neovim is managed by Bob at `~/.local/share/bob/nvim-bin/nvim`.
+
+## Step 0 — Network policy is a hard prerequisite
+
+The `nvim-fredrik` config bootstraps plugins with `vim.pack.add`, which clones
+from **github.com** on first launch. Mason and treesitter fetch from GitHub
+too. The sandbox network policy is registry-only by default, so GitHub is
+**blocked** until the environment allowlists it.
+
+Check reachability first:
+
+```bash
+curl -sSI -o /dev/null -w "%{http_code}\n" https://github.com/neovim/neovim/releases/tag/nightly
+```
+
+`200`/`302` → proceed. `403`/`000` → **stop.** The environment must allowlist
+these hosts before anything here can work:
+
+- `github.com`
+- `objects.githubusercontent.com`
+- `raw.githubusercontent.com`
+- `github-releases.githubusercontent.com`
+
+Tell the user to add them to the environment's allowed hosts (claude.ai
+environment editor → network / allowed hosts) and rebuild the environment, then
+re-run this skill. This is an environment-config change; nothing in the repo can
+route around it. See
+https://code.claude.com/docs/en/claude-code-on-the-web for how network policy
+and allowed hosts work.
+
+## Step 1 — Install the Neovim binary (nightly)
+
+`nvim-fredrik` requires **nightly** Neovim: it uses `vim.pack.add` and
+`vim._core.ui2`, which are not in any stable release. Use the `.tar.gz`
+(no FUSE/AppImage dependency):
+
+```bash
+set -e
+arch="$(uname -m)"   # x86_64 in the sandbox; arm64 hosts use nvim-linux-arm64
+asset="nvim-linux-${arch}.tar.gz"
+curl -fL -o "/tmp/${asset}" \
+  "https://github.com/neovim/neovim/releases/download/nightly/${asset}"
+rm -rf /opt/nvim && mkdir -p /opt/nvim
+tar -xzf "/tmp/${asset}" -C /opt/nvim --strip-components=1
+export PATH="/opt/nvim/bin:$PATH"
+nvim --version | head -1   # expect a v0.12.0-dev... nightly build
+```
+
+(This `export` is only for the immediate check — Step 2 persists `PATH` and the
+rest so they survive across shells.)
+
+If the asset name 404s, list the release assets and pick the current Linux
+tarball name — Neovim has renamed these before (`nvim-linux64.tar.gz` →
+`nvim-linux-x86_64.tar.gz`):
+
+```bash
+curl -fL https://api.github.com/repos/neovim/neovim/releases/tags/nightly \
+  | grep -o '"name": "nvim-linux[^"]*"'
+```
+
+## Step 2 — Wire the nvim-fredrik config into place
+
+The config lives in the cloned repo. `NVIM_APPNAME=nvim-fredrik` makes Neovim
+read `~/.config/nvim-fredrik`, and the config expects `$DOTFILES` set (it
+defaults to `~/.dotfiles`, which does not exist here).
+
+**The sandbox runs each command in a fresh shell initialized from your
+profile**, so plain `export`s do not survive from one Bash call to the next —
+and the `neovim` skill you hand off to later relies on `$NVIM` being present.
+Persist the environment into a file the profile sources, so every subsequent
+shell (and the `neovim` skill) inherits it:
+
+```bash
+repo="/home/user/dotfiles"        # adjust if the repo is cloned elsewhere
+mkdir -p ~/.config
+ln -sfn "$repo/nvim-fredrik" ~/.config/nvim-fredrik
+
+cat > ~/.nvim-sandbox.env <<EOF
+export PATH="/opt/nvim/bin:\$PATH"
+export DOTFILES="$repo"
+export NVIM_APPNAME=nvim-fredrik
+export NVIM=/tmp/nvim-fredrik.sock
+EOF
+grep -qxF 'source ~/.nvim-sandbox.env' ~/.bashrc 2>/dev/null \
+  || echo 'source ~/.nvim-sandbox.env' >> ~/.bashrc
+source ~/.nvim-sandbox.env
+```
+
+## Step 3 — Launch Neovim headless with a listen socket
+
+This is the bridge to the `neovim` skill. Start a backgrounded headless
+instance listening on `$NVIM` (persisted in Step 2), so the RPC skill's
+commands — which all key off `$NVIM` — work unchanged. The **first** launch
+clones all plugins via `vim.pack.add` (needs the Step 0 network access) and can
+take a few minutes.
+
+```bash
+rm -f "$NVIM"
+# --headless keeps it alive as long as the socket is served; run detached.
+nohup nvim --headless --listen "$NVIM" >/tmp/nvim-headless.log 2>&1 &
+# Wait for the socket to accept RPC (plugin cloning happens during startup).
+for i in $(seq 1 120); do
+  [ -S "$NVIM" ] && nvim --server "$NVIM" --remote-expr '1' >/dev/null 2>&1 && break
+  sleep 2
+done
+echo "NVIM socket: $NVIM"; tail -5 /tmp/nvim-headless.log
+```
+
+If the loop times out, read `/tmp/nvim-headless.log` — plugin clone failures
+almost always mean a GitHub host is still not allowlisted (back to Step 0).
+
+## Step 4 — Verify and hand off to the `neovim` skill
+
+Because `NVIM_APPNAME` is set, every `nvim --server` command prints a
+`Warning: Using NVIM_APPNAME=...` line on **stdout** that corrupts parsed
+output. Filter it exactly as the `neovim` skill documents:
+
+```bash
+result=$(nvim --server "$NVIM" --remote-expr 'v:version') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
+result=$(nvim --server "$NVIM" --remote-expr 'luaeval("vim.fn.stdpath(\"config\")")') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
+```
+
+From here, `$NVIM` is set exactly as if Claude Code were running inside a
+Neovim terminal, so **switch to the `neovim` skill** for all further
+interaction (buffer state, running Lua, inspecting diagnostics, LSP, plugins) —
+including its `grep -v` filtering pattern.
+
+## Testing a config-change PR
+
+The `nvim-fredrik` config is part of *this* repo, so a PR that changes it is
+just a branch checkout — no separate config repo:
+
+```bash
+git -C /home/user/dotfiles fetch origin <pr-branch>
+git -C /home/user/dotfiles checkout <pr-branch>
+```
+
+Then restart the headless instance so the new config is sourced:
+
+```bash
+nvim --server "$NVIM" --remote-expr 'execute("qa!")' 2>/dev/null || true
+rm -f "$NVIM"
+nohup nvim --headless --listen "$NVIM" >/tmp/nvim-headless.log 2>&1 &
+for i in $(seq 1 120); do
+  [ -S "$NVIM" ] && nvim --server "$NVIM" --remote-expr '1' >/dev/null 2>&1 && break
+  sleep 2
+done
+```
+
+Now drive the behavior under test via the `neovim` skill. For example, to
+exercise a neotest/diagnostics change: open a test file, run the relevant
+command, then read the diagnostics namespace:
+
+```bash
+nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")'
+```
+
+## Caveats
+
+- **First launch is slow** — plugin cloning is network-bound and serial.
+- **Mason / LSP servers and treesitter parsers are best-effort.** They pull
+  extra tools from GitHub and compile locally; if a change under test doesn't
+  depend on a language server, you don't need them. Failures here are logged in
+  `/tmp/nvim-headless.log` and don't prevent the rest of the config loading.
+- **Headless has no UI.** Inspect state via RPC (`vim.diagnostic.get`,
+  `vim.lsp.get_clients`, buffer APIs), not by looking at a screen.
+- **Ephemeral.** The install lives only for this environment's lifetime; nothing
+  is committed. Re-run the skill in a fresh environment.

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nvim-install
-description: Install Neovim (via bob) and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs bob with cargo, uses bob to install a stable or nightly Neovim, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only; on a real machine Neovim is already managed by bob.
+description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs Nix via apt and a vim.pack-capable Neovim (0.12.x) from the Nix binary cache with no GitHub access, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only.
 ---
 
 # Install Neovim in the web sandbox
@@ -9,72 +9,76 @@ This skill bootstraps a real, running Neovim in the Claude Code web sandbox so
 config changes (e.g. a PR against `nvim-fredrik`) can be exercised and observed.
 It is the missing half of the `neovim` RPC skill: that skill assumes a running
 Neovim exposed via `$NVIM`, but the sandbox has neither the binary nor a parent
-editor. This skill installs Neovim with **bob** (the same version manager used
-on the real machines, so stable/nightly is a one-word switch), launches Neovim
-**headless** with a listen socket, and exports `$NVIM` so every command in the
-`neovim` skill works verbatim afterwards.
+editor. This skill installs the binary, launches Neovim **headless** with a
+listen socket, and exports `$NVIM` so every command in the `neovim` skill works
+verbatim afterwards.
 
 **Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). Do not run on a real
-machine — there bob already manages Neovim at
-`~/.local/share/bob/nvim-bin/nvim`.
+machine — there Neovim is managed by bob at `~/.local/share/bob/nvim-bin/nvim`.
 
-## Step 0 — GitHub access is a hard prerequisite
+## The install path: Nix (verified best for the sandbox)
 
-bob fetches Neovim from **github.com/neovim/neovim** (release list via
-`api.github.com`, binaries via the release asset host). In the sandbox, GitHub
-traffic is gated by the agent proxy to the **repos in this session's scope** —
-by default only this dotfiles repo. bob's calls to `neovim/neovim` are denied
-until that repo is in scope, failing with:
+The sandbox network is locked to package registries plus this session's GitHub
+repos. Two facts make **Nix** the cleanest binary source, better than bob or a
+GitHub tarball:
 
-> ERROR Error: GitHub access to this repository is not enabled for this
-> session. Use add_repo to request access.
+- `apt` reaches the main Ubuntu archive, and **`nix-bin` is in it**.
+- `cache.nixos.org` and `channels.nixos.org` are reachable through the proxy,
+  so Nix substitutes prebuilt binaries **without any GitHub access**.
+- `nixpkgs-unstable` currently ships **Neovim 0.12.x**, which has both
+  `vim.pack` and `vim._core.ui2` — exactly what `nvim-fredrik` requires. (bob
+  and a nightly tarball both need GitHub even to fetch the binary; Nix does
+  not.)
 
-**Enable access before continuing.** The simplest path is to bring
-`neovim/neovim` into the session scope with `add_repo` (ask Claude: *"add the
-neovim/neovim repo"* — Claude only runs `add_repo` when you ask). Alternatively,
-widen the environment's network policy / allowed hosts to include
-`github.com`, `api.github.com`, `objects.githubusercontent.com`, and
-`github-releases.githubusercontent.com`, then rebuild the environment. See
-https://code.claude.com/docs/en/claude-code-on-the-web for how network policy
-and session scope work.
+## Step 0 — Network prerequisites
 
-Preflight — once access is enabled, this lists remote versions instead of
-erroring:
+Two independent needs, in order of when they bite:
+
+1. **The binary (this skill):** the Ubuntu archive, `channels.nixos.org`, and
+   `cache.nixos.org`. These are reachable in the default sandbox policy — no
+   action normally needed. Verify:
+
+   ```bash
+   curl -sSI -o /dev/null -w "cache:    %{http_code}\n" https://cache.nixos.org
+   curl -sSI -o /dev/null -w "channels: %{http_code}\n" https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+   ```
+
+   `200`/`302` → good.
+
+2. **The plugins (to actually run `nvim-fredrik`):** at startup `vim.pack`
+   clones ~50 plugins from **github.com** and **codeberg.org**. Both are
+   **blocked by default** (`403` through the proxy), so the config installs the
+   binary and *starts*, but plugin cloning fails until the environment's network
+   policy allows those hosts. This is an environment-config change (claude.ai
+   environment editor → network / allowed hosts; add `github.com` and
+   `codeberg.org`), then rebuild the environment. See
+   https://code.claude.com/docs/en/claude-code-on-the-web. Nothing in the repo
+   can route around it — the binary can be installed without it, but a full
+   plugin sync cannot.
+
+## Step 1 — Install Nix (via apt)
 
 ```bash
-export PATH="$HOME/.cargo/bin:$PATH"
-bob list-remote 2>&1 | tail -5    # errors here => GitHub access still not enabled
+apt-get update -qq
+apt-get install -y --no-install-recommends nix-bin
+# Single-user (rootless-build) mode: no nixbld group exists in the sandbox.
+mkdir -p /etc/nix
+grep -q '^build-users-group' /etc/nix/nix.conf 2>/dev/null \
+  || echo 'build-users-group =' >> /etc/nix/nix.conf
+nix --version
 ```
 
-## Step 1 — Install bob (via cargo)
+## Step 2 — Install Neovim from nixpkgs-unstable
 
-The sandbox ships the Rust toolchain (`cargo`, `rustc`), and cargo can reach
-crates.io, so bob builds from source in ~90s. bob itself needs **no** GitHub
-access to install — only its later Neovim downloads do (Step 0).
-
-```bash
-command -v bob >/dev/null || cargo install bob-nvim
-export PATH="$HOME/.cargo/bin:$PATH"
-bob --version
-```
-
-## Step 2 — Install and select a Neovim version
-
-`nvim-fredrik` requires **nightly** Neovim: it uses `vim.pack.add` and
-`vim._core.ui2`, which are not in any stable release. (For other configs, swap
-`nightly` for `stable` or a version like `v0.11.0` — that's the whole benefit
-of bob.)
+`nvim-fredrik` requires `vim.pack` and `vim._core.ui2`, which land in Neovim
+0.12.x — provided by `nixpkgs-unstable`. Everything is substituted from
+`cache.nixos.org`; nothing is compiled and no GitHub is touched.
 
 ```bash
-bob use nightly        # installs if missing, then makes it the active version
-```
-
-bob places the active binary at `~/.local/share/bob/nvim-bin/nvim`. Add that to
-`PATH`:
-
-```bash
-export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
-nvim --version | head -1   # expect a v0.12.0-dev... nightly build
+nix-env -iA neovim -f https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz
+export PATH="$HOME/.nix-profile/bin:$PATH"
+nvim --version | head -1                       # expect NVIM v0.12.x
+nvim --headless -c 'lua io.write(tostring(vim.pack ~= nil))' -c 'qa'   # expect: true
 ```
 
 ## Step 3 — Wire the config into place and persist the environment
@@ -95,7 +99,7 @@ mkdir -p ~/.config
 ln -sfn "$repo/nvim-fredrik" ~/.config/nvim-fredrik
 
 cat > ~/.nvim-sandbox.env <<EOF
-export PATH="\$HOME/.cargo/bin:\$HOME/.local/share/bob/nvim-bin:\$PATH"
+export PATH="\$HOME/.nix-profile/bin:\$PATH"
 export DOTFILES="$repo"
 export NVIM_APPNAME=nvim-fredrik
 export NVIM=/tmp/nvim-fredrik.sock
@@ -110,8 +114,8 @@ source ~/.nvim-sandbox.env
 This is the bridge to the `neovim` skill. Start a backgrounded headless
 instance listening on `$NVIM` (persisted in Step 3), so the RPC skill's
 commands — which all key off `$NVIM` — work unchanged. The **first** launch
-clones all plugins via `vim.pack.add` (needs the Step 0 GitHub access) and can
-take a few minutes.
+clones all plugins via `vim.pack` (needs the Step 0 plugin-network access) and
+can take a few minutes.
 
 ```bash
 rm -f "$NVIM"
@@ -122,27 +126,26 @@ for i in $(seq 1 120); do
   [ -S "$NVIM" ] && nvim --server "$NVIM" --remote-expr '1' >/dev/null 2>&1 && break
   sleep 2
 done
-echo "NVIM socket: $NVIM"; tail -5 /tmp/nvim-headless.log
+echo "NVIM socket: $NVIM"; tail -8 /tmp/nvim-headless.log
 ```
 
-If the loop times out, read `/tmp/nvim-headless.log` — plugin clone failures
-almost always mean GitHub access is still not enabled (back to Step 0).
+`403` / `CONNECT tunnel failed` lines in the log mean github.com/codeberg.org
+are still not allowed (back to Step 0, item 2). The editor still runs; only the
+plugins that failed to clone are missing.
 
 ## Step 5 — Verify and hand off to the `neovim` skill
 
-Because `NVIM_APPNAME` is set, every `nvim --server` command prints a
-`Warning: Using NVIM_APPNAME=...` line on **stdout** that corrupts parsed
-output. Filter it exactly as the `neovim` skill documents:
-
 ```bash
-result=$(nvim --server "$NVIM" --remote-expr 'v:version') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
-result=$(nvim --server "$NVIM" --remote-expr 'luaeval("vim.fn.stdpath(\"config\")")') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
+nvim --server "$NVIM" --remote-expr 'v:version'
+nvim --server "$NVIM" --remote-expr 'luaeval("vim.fn.stdpath(\"config\")")'
 ```
 
-From here, `$NVIM` is set exactly as if Claude Code were running inside a
-Neovim terminal, so **switch to the `neovim` skill** for all further
-interaction (buffer state, running Lua, inspecting diagnostics, LSP, plugins) —
-including its `grep -v` filtering pattern.
+`$NVIM` is now set exactly as if Claude Code were running inside a Neovim
+terminal, so **switch to the `neovim` skill** for all further interaction
+(buffer state, running Lua, inspecting diagnostics, LSP, plugins). Note: the
+`neovim` skill's `NVIM_APPNAME` stdout-warning filter is aimed at the dotfiles
+`nvim` wrapper; here you invoke the real binary directly, so the warning usually
+does not appear — the filter is harmless either way.
 
 ## Testing a config-change PR
 
@@ -166,26 +169,38 @@ for i in $(seq 1 120); do
 done
 ```
 
-Now drive the behavior under test via the `neovim` skill. For example, to
-exercise a neotest/diagnostics change: open a test file, run the relevant
-command, then read the diagnostics namespace:
+Now drive the behavior under test via the `neovim` skill — e.g. for a
+neotest/diagnostics change, open a test file, run the command, then read the
+diagnostics:
 
 ```bash
-result=$(nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
+nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")'
 ```
+
+## Alternatives to the Nix path
+
+- **bob** (matches the real machines, one-word stable/nightly): the Rust
+  toolchain is preinstalled, so `cargo install bob-nvim` works with no GitHub.
+  But `bob install nightly` downloads Neovim from **github.com/neovim/neovim**,
+  which the proxy gates to the session's repo scope — enable it with
+  `add_repo neovim/neovim` (ask Claude) or by widening the network policy. Then
+  `bob use nightly` puts the binary at `~/.local/share/bob/nvim-bin/nvim`.
+- **Direct tarball** (no Rust): `curl -fL
+  https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-$(uname -m).tar.gz
+  | tar -xz -C /opt/nvim --strip-components=1` — same GitHub-access prerequisite
+  as bob.
+
+Both alternatives still hit the Step 0 plugin-network requirement for a full
+`nvim-fredrik` run; only the binary source differs.
 
 ## Caveats
 
 - **First launch is slow** — plugin cloning is network-bound and serial.
 - **Mason / LSP servers and treesitter parsers are best-effort.** They pull
   extra tools from GitHub and compile locally; if a change under test doesn't
-  depend on a language server, you don't need them. Failures here are logged in
+  depend on a language server, you don't need them. Failures are logged in
   `/tmp/nvim-headless.log` and don't prevent the rest of the config loading.
 - **Headless has no UI.** Inspect state via RPC (`vim.diagnostic.get`,
   `vim.lsp.get_clients`, buffer APIs), not by looking at a screen.
-- **Ephemeral.** bob's install and the config live only for this environment's
+- **Ephemeral.** The install and config live only for this environment's
   lifetime; nothing is committed. Re-run the skill in a fresh environment.
-- **Fallback without bob:** if cargo/bob is unavailable, download a release
-  tarball directly (no Rust needed) — the tag selects the channel:
-  `curl -fL https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-$(uname -m).tar.gz | tar -xz -C /opt/nvim --strip-components=1`
-  (same GitHub-access prerequisite as Step 0).

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -1,80 +1,83 @@
 ---
 name: nvim-install
-description: Install Neovim and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Downloads the nightly Neovim tarball, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only; on a real machine Neovim is managed by Bob.
+description: Install Neovim (via bob) and stand up the nvim-fredrik config in the Claude Code web sandbox (the cloud environment), where no Neovim exists. Use this before testing any Neovim config change in a web session, e.g. checking out a PR branch that touches nvim-fredrik and observing its runtime behavior. Installs bob with cargo, uses bob to install a stable or nightly Neovim, wires the repo's config into place, launches Neovim headless with a listen socket, and exports $NVIM so the `neovim` RPC skill can drive it. Web-sandbox only; on a real machine Neovim is already managed by bob.
 ---
 
 # Install Neovim in the web sandbox
 
 This skill bootstraps a real, running Neovim in the Claude Code web sandbox so
-that config changes (e.g. a PR against `nvim-fredrik`) can be exercised and
-observed. It is the missing half of the `neovim` RPC skill: that skill assumes
-a running Neovim exposed via `$NVIM`, but the sandbox has neither the binary
-nor a parent editor. This skill installs the binary, launches Neovim
+config changes (e.g. a PR against `nvim-fredrik`) can be exercised and observed.
+It is the missing half of the `neovim` RPC skill: that skill assumes a running
+Neovim exposed via `$NVIM`, but the sandbox has neither the binary nor a parent
+editor. This skill installs Neovim with **bob** (the same version manager used
+on the real machines, so stable/nightly is a one-word switch), launches Neovim
 **headless** with a listen socket, and exports `$NVIM` so every command in the
 `neovim` skill works verbatim afterwards.
 
 **Scope:** web sandbox only (`CLAUDE_CODE_REMOTE=true`). Do not run on a real
-machine — there Neovim is managed by Bob at `~/.local/share/bob/nvim-bin/nvim`.
+machine — there bob already manages Neovim at
+`~/.local/share/bob/nvim-bin/nvim`.
 
-## Step 0 — Network policy is a hard prerequisite
+## Step 0 — GitHub access is a hard prerequisite
 
-The `nvim-fredrik` config bootstraps plugins with `vim.pack.add`, which clones
-from **github.com** on first launch. Mason and treesitter fetch from GitHub
-too. The sandbox network policy is registry-only by default, so GitHub is
-**blocked** until the environment allowlists it.
+bob fetches Neovim from **github.com/neovim/neovim** (release list via
+`api.github.com`, binaries via the release asset host). In the sandbox, GitHub
+traffic is gated by the agent proxy to the **repos in this session's scope** —
+by default only this dotfiles repo. bob's calls to `neovim/neovim` are denied
+until that repo is in scope, failing with:
 
-Check reachability first:
+> ERROR Error: GitHub access to this repository is not enabled for this
+> session. Use add_repo to request access.
+
+**Enable access before continuing.** The simplest path is to bring
+`neovim/neovim` into the session scope with `add_repo` (ask Claude: *"add the
+neovim/neovim repo"* — Claude only runs `add_repo` when you ask). Alternatively,
+widen the environment's network policy / allowed hosts to include
+`github.com`, `api.github.com`, `objects.githubusercontent.com`, and
+`github-releases.githubusercontent.com`, then rebuild the environment. See
+https://code.claude.com/docs/en/claude-code-on-the-web for how network policy
+and session scope work.
+
+Preflight — once access is enabled, this lists remote versions instead of
+erroring:
 
 ```bash
-curl -sSI -o /dev/null -w "%{http_code}\n" https://github.com/neovim/neovim/releases/tag/nightly
+export PATH="$HOME/.cargo/bin:$PATH"
+bob list-remote 2>&1 | tail -5    # errors here => GitHub access still not enabled
 ```
 
-`200`/`302` → proceed. `403`/`000` → **stop.** The environment must allowlist
-these hosts before anything here can work:
+## Step 1 — Install bob (via cargo)
 
-- `github.com`
-- `objects.githubusercontent.com`
-- `raw.githubusercontent.com`
-- `github-releases.githubusercontent.com`
-
-Tell the user to add them to the environment's allowed hosts (claude.ai
-environment editor → network / allowed hosts) and rebuild the environment, then
-re-run this skill. This is an environment-config change; nothing in the repo can
-route around it. See
-https://code.claude.com/docs/en/claude-code-on-the-web for how network policy
-and allowed hosts work.
-
-## Step 1 — Install the Neovim binary (nightly)
-
-`nvim-fredrik` requires **nightly** Neovim: it uses `vim.pack.add` and
-`vim._core.ui2`, which are not in any stable release. Use the `.tar.gz`
-(no FUSE/AppImage dependency):
+The sandbox ships the Rust toolchain (`cargo`, `rustc`), and cargo can reach
+crates.io, so bob builds from source in ~90s. bob itself needs **no** GitHub
+access to install — only its later Neovim downloads do (Step 0).
 
 ```bash
-set -e
-arch="$(uname -m)"   # x86_64 in the sandbox; arm64 hosts use nvim-linux-arm64
-asset="nvim-linux-${arch}.tar.gz"
-curl -fL -o "/tmp/${asset}" \
-  "https://github.com/neovim/neovim/releases/download/nightly/${asset}"
-rm -rf /opt/nvim && mkdir -p /opt/nvim
-tar -xzf "/tmp/${asset}" -C /opt/nvim --strip-components=1
-export PATH="/opt/nvim/bin:$PATH"
+command -v bob >/dev/null || cargo install bob-nvim
+export PATH="$HOME/.cargo/bin:$PATH"
+bob --version
+```
+
+## Step 2 — Install and select a Neovim version
+
+`nvim-fredrik` requires **nightly** Neovim: it uses `vim.pack.add` and
+`vim._core.ui2`, which are not in any stable release. (For other configs, swap
+`nightly` for `stable` or a version like `v0.11.0` — that's the whole benefit
+of bob.)
+
+```bash
+bob use nightly        # installs if missing, then makes it the active version
+```
+
+bob places the active binary at `~/.local/share/bob/nvim-bin/nvim`. Add that to
+`PATH`:
+
+```bash
+export PATH="$HOME/.local/share/bob/nvim-bin:$PATH"
 nvim --version | head -1   # expect a v0.12.0-dev... nightly build
 ```
 
-(This `export` is only for the immediate check — Step 2 persists `PATH` and the
-rest so they survive across shells.)
-
-If the asset name 404s, list the release assets and pick the current Linux
-tarball name — Neovim has renamed these before (`nvim-linux64.tar.gz` →
-`nvim-linux-x86_64.tar.gz`):
-
-```bash
-curl -fL https://api.github.com/repos/neovim/neovim/releases/tags/nightly \
-  | grep -o '"name": "nvim-linux[^"]*"'
-```
-
-## Step 2 — Wire the nvim-fredrik config into place
+## Step 3 — Wire the config into place and persist the environment
 
 The config lives in the cloned repo. `NVIM_APPNAME=nvim-fredrik` makes Neovim
 read `~/.config/nvim-fredrik`, and the config expects `$DOTFILES` set (it
@@ -92,7 +95,7 @@ mkdir -p ~/.config
 ln -sfn "$repo/nvim-fredrik" ~/.config/nvim-fredrik
 
 cat > ~/.nvim-sandbox.env <<EOF
-export PATH="/opt/nvim/bin:\$PATH"
+export PATH="\$HOME/.cargo/bin:\$HOME/.local/share/bob/nvim-bin:\$PATH"
 export DOTFILES="$repo"
 export NVIM_APPNAME=nvim-fredrik
 export NVIM=/tmp/nvim-fredrik.sock
@@ -102,12 +105,12 @@ grep -qxF 'source ~/.nvim-sandbox.env' ~/.bashrc 2>/dev/null \
 source ~/.nvim-sandbox.env
 ```
 
-## Step 3 — Launch Neovim headless with a listen socket
+## Step 4 — Launch Neovim headless with a listen socket
 
 This is the bridge to the `neovim` skill. Start a backgrounded headless
-instance listening on `$NVIM` (persisted in Step 2), so the RPC skill's
+instance listening on `$NVIM` (persisted in Step 3), so the RPC skill's
 commands — which all key off `$NVIM` — work unchanged. The **first** launch
-clones all plugins via `vim.pack.add` (needs the Step 0 network access) and can
+clones all plugins via `vim.pack.add` (needs the Step 0 GitHub access) and can
 take a few minutes.
 
 ```bash
@@ -123,9 +126,9 @@ echo "NVIM socket: $NVIM"; tail -5 /tmp/nvim-headless.log
 ```
 
 If the loop times out, read `/tmp/nvim-headless.log` — plugin clone failures
-almost always mean a GitHub host is still not allowlisted (back to Step 0).
+almost always mean GitHub access is still not enabled (back to Step 0).
 
-## Step 4 — Verify and hand off to the `neovim` skill
+## Step 5 — Verify and hand off to the `neovim` skill
 
 Because `NVIM_APPNAME` is set, every `nvim --server` command prints a
 `Warning: Using NVIM_APPNAME=...` line on **stdout** that corrupts parsed
@@ -168,7 +171,7 @@ exercise a neotest/diagnostics change: open a test file, run the relevant
 command, then read the diagnostics namespace:
 
 ```bash
-nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")'
+result=$(nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get(0))")') && echo "$result" | grep -v '^Warning: Using NVIM_APPNAME='
 ```
 
 ## Caveats
@@ -180,5 +183,9 @@ nvim --server "$NVIM" --remote-expr 'luaeval("vim.json.encode(vim.diagnostic.get
   `/tmp/nvim-headless.log` and don't prevent the rest of the config loading.
 - **Headless has no UI.** Inspect state via RPC (`vim.diagnostic.get`,
   `vim.lsp.get_clients`, buffer APIs), not by looking at a screen.
-- **Ephemeral.** The install lives only for this environment's lifetime; nothing
-  is committed. Re-run the skill in a fresh environment.
+- **Ephemeral.** bob's install and the config live only for this environment's
+  lifetime; nothing is committed. Re-run the skill in a fresh environment.
+- **Fallback without bob:** if cargo/bob is unavailable, download a release
+  tarball directly (no Rust needed) — the tag selects the channel:
+  `curl -fL https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-$(uname -m).tar.gz | tar -xz -C /opt/nvim --strip-components=1`
+  (same GitHub-access prerequisite as Step 0).

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -86,9 +86,17 @@ nvim --headless -c 'lua io.write(tostring(vim.pack ~= nil))' -c 'qa'  # expect: 
 
 ## Step 3 — Wire the config into place and persist the environment
 
-The config lives in the cloned repo. `NVIM_APPNAME=nvim-fredrik` makes Neovim
-read `~/.config/nvim-fredrik`, and the config expects `$DOTFILES` set (it
-defaults to `~/.dotfiles`, which does not exist here).
+The config lives in the cloned repo. Two env vars point Neovim at it:
+
+- **`NVIM_APPNAME=nvim-fredrik`** makes Neovim read `~/.config/nvim-fredrik`
+  (the symlink created below).
+- **`$DOTFILES`** is the **dotfiles repo root**. The config builds paths from it
+  to other repo files — the Mason lockfile
+  (`$DOTFILES/nvim-fredrik/mason-lock.json`), lint configs
+  (`$DOTFILES/extras/templates/...`), and snippets. Left unset, `init.lua` falls
+  back to `~/.dotfiles`; startup still succeeds, but that path doesn't exist in
+  the sandbox, so those lockfile/lint/snippet lookups silently resolve to
+  missing files. Point it at the clone root so they resolve.
 
 **The sandbox runs each command in a fresh shell initialized from your
 profile**, so plain `export`s do not survive from one Bash call to the next —


### PR DESCRIPTION
## Why?

- The Claude Code web sandbox has no Neovim, so `nvim-fredrik` config changes (e.g. a PR that touches it) can't be exercised or observed there.
- The existing `neovim` RPC skill drives a *running* instance via `$NVIM`, but nothing in the sandbox installs Neovim or launches it — the skill has nothing to talk to.

## What?

- Add a general-purpose **`nix-install`** skill: `apt install nix-bin` + substitute any nixpkgs tool from `cache.nixos.org` via the channel tarball, with no GitHub access.
- Add an **`nvim-install`** skill that builds on it: install Neovim via Nix (nixpkgs-unstable 0.12.x, which has `vim.pack` + `vim._core.ui2`), launch it **headless with `--listen`**, and export `$NVIM` so the RPC skill works verbatim. bob is documented as an opt-in for explicit stable/nightly management.
- Symlink the `neovim` RPC skill into `.claude-web` so install + drive compose in web sessions.

## Notes

- Verified live in the sandbox: `nix-bin` installs via apt; Neovim 0.12.4 (`vim.pack` + `vim._core.ui2` present) substitutes from `cache.nixos.org` with **no GitHub**; headless launch + `$NVIM` + RPC round-trip all work.
- Two independent gates gate a *full* `nvim-fredrik` run: (1) **network access level** — public GitHub plugin clones already work under the default Trusted policy, but `codeberg.org` (nvim-dap, nvim-dap-python, nvim-lint) must be added via **Custom → Allowed domains**; (2) the **GitHub proxy** — release-asset deps (codediff lib, Mason, treesitter) are scoped to attached repos regardless of network level, and are optional for most config testing.
- bob installs from Nix fine, but its Neovim download is a GitHub release asset — needs `add_repo neovim/neovim`, which network level can't override. Hence Nix is the default.
- Web-sandbox only (`CLAUDE_CODE_REMOTE=true`); on real machines Neovim is managed by bob as before.