### PR TITLE
feat(nvim): collapse neotest diagnostic virtual text to one line

### DIFF
--- a/nvim-fredrik/plugin/neotest.lua
+++ b/nvim-fredrik/plugin/neotest.lua
@@ -19,6 +19,21 @@ require("lazyload").on_vim_enter(function()
 
   local neotest = require("neotest")
 
+  -- Get neotest namespace (api call creates or returns namespace). This is
+  -- optional but recommended if you enabled the diagnostic option of neotest.
+  -- Especially testify makes heavy use of tabs and newlines in the error
+  -- messages, which reduces the readability of the generated virtual text
+  -- otherwise.
+  local neotest_ns = vim.api.nvim_create_namespace("neotest")
+  vim.diagnostic.config({
+    virtual_text = {
+      format = function(diagnostic)
+        local message = diagnostic.message:gsub("\n", " "):gsub("\t", " "):gsub("%s+", " "):gsub("^%s+", "")
+        return message
+      end,
+    },
+  }, neotest_ns)
+
   ---@diagnostic disable-next-line: missing-fields
   neotest.setup({
     adapters = {


### PR DESCRIPTION
## Why?

- neotest renders diagnostic messages as virtual text, but testify failures are full of tabs and newlines, so the virtual text is barely readable.
- Supersedes #151, which made the same improvement against the old lazy.nvim config (`lua/plugins/neotest.lua`) that no longer exists after the migration to native `vim.pack`.

## What?

- Register a `vim.diagnostic` format function on the `neotest` namespace that strips newlines/tabs and squeezes runs of whitespace, in the current [plugin/neotest.lua](https://github.com/fredrikaverpil/dotfiles/blob/a0b1522d188f7c9265828584d00e29c4462f1b98/nvim-fredrik/plugin/neotest.lua#L22-L35).

```lua
local neotest_ns = vim.api.nvim_create_namespace("neotest")
vim.diagnostic.config({
  virtual_text = {
    format = function(diagnostic)
      return diagnostic.message:gsub("\n", " "):gsub("\t", " "):gsub("%s+", " "):gsub("^%s+", "")
    end,
  },
}, neotest_ns)
```

## Notes

- Verified live in headless Neovim: a testify-style message collapses from `\n\tError Trace:\tfoo_test.go:42\n\tError:\t\tNot equal:\n...` to `Error Trace: foo_test.go:42 Error: Not equal: expected: 3 actual : 4 Test: TestAdd` — no newlines, tabs, double-spaces, or leading whitespace.
- Closes #151 in favor of this PR.