### PR TITLE
fix(claude): make nvim-install restart safe against two footguns

### DIFF
--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -125,6 +125,7 @@ source ~/.nvim-sandbox.env        # env doesn't persist across calls; re-source
 rm -f "$NVIM"
 # --headless keeps it alive as long as the socket is served; run detached.
 nohup nvim --headless --listen "$NVIM" >/tmp/nvim-headless.log 2>&1 &
+echo $! > /tmp/nvim-fredrik.pid   # record PID so a later restart can kill it
 # Wait for the socket to accept RPC (plugin cloning happens during startup).
 for i in $(seq 1 120); do
   [ -S "$NVIM" ] && nvim --server "$NVIM" --remote-expr '1' >/dev/null 2>&1 && break
@@ -162,16 +163,32 @@ git -C /home/user/dotfiles fetch origin <pr-branch>
 git -C /home/user/dotfiles checkout <pr-branch>
 ```
 
-Then restart the headless instance so the new config is sourced. Stop the old
-instance deterministically first — a `--remote-expr` quit can race the relaunch
-below and leave the old process orphaned, still serving the previous config —
-then relaunch exactly as in Step 4:
+Then restart the headless instance so the new config is sourced. Kill the old
+instance by the PID recorded at launch and **wait until it is actually gone**
+before relaunching. Two traps make this fiddlier than it looks:
+
+- **Don't `pkill -f 'nvim --headless --listen'`.** Each Bash call runs as
+  `bash -c '<the whole script>'`, so that string is in the script shell's own
+  arguments; `pkill -f` matches and kills the script itself, which dies with a
+  `128 + signal` exit (e.g. `143`/`144`) before it ever relaunches. Killing the
+  recorded PID sidesteps the pattern entirely.
+- **Let the old process exit before reusing `$NVIM`.** A dying nvim unlinks its
+  own socket on the way out. Relaunch on the same path too soon and the old
+  instance's cleanup deletes the *new* socket — RPC then fails with "connection
+  refused" even though the new process is alive. So confirm it's gone (SIGKILL
+  as a fallback) before `rm`-ing the path and starting fresh.
 
 ```bash
 source ~/.nvim-sandbox.env
-pkill -f 'nvim --headless --listen' 2>/dev/null || true
+oldpid="$(cat /tmp/nvim-fredrik.pid 2>/dev/null)"
+if [ -n "$oldpid" ]; then
+  kill "$oldpid" 2>/dev/null || true
+  for i in $(seq 1 50); do kill -0 "$oldpid" 2>/dev/null || break; sleep 0.2; done
+  kill -9 "$oldpid" 2>/dev/null || true   # force if it ignored SIGTERM
+fi
 rm -f "$NVIM"
 nohup nvim --headless --listen "$NVIM" >/tmp/nvim-headless.log 2>&1 &
+echo $! > /tmp/nvim-fredrik.pid
 for i in $(seq 1 120); do
   [ -S "$NVIM" ] && nvim --server "$NVIM" --remote-expr '1' >/dev/null 2>&1 && break
   sleep 2

--- a/stow/shared/.claude-web/skills/nvim-install/SKILL.md
+++ b/stow/shared/.claude-web/skills/nvim-install/SKILL.md
@@ -153,6 +153,41 @@ all further interaction (buffer state, running Lua, inspecting diagnostics, LSP,
 plugins). Start each of those Bash calls with `source ~/.nvim-sandbox.env` too —
 the env doesn't carry over on its own.
 
+## One-shot checks (skip the persistent server)
+
+Steps 4–5 stand up a *persistent* `--listen` server so the `neovim` skill can
+drive it across turns. You only need that for interactive, multi-step work. For
+an observe-once question — *does this config change load cleanly? what does the
+formatter do to this file?* — skip the socket entirely and use a
+**self-terminating** headless run that loads the real config, does its thing,
+prints, and quits with `qa!`. It exits cleanly and sidesteps all of the
+launch/restart/socket handling (and its footguns) above. Prefer it whenever you
+don't actually need cross-turn RPC.
+
+```bash
+source ~/.nvim-sandbox.env
+# "does my config change load without error?"
+nvim --headless \
+  -c 'lua io.write("config="..vim.fn.stdpath("config").."\n")' \
+  -c 'qa!'
+```
+
+Exercising behaviour follows the same shape — open a file so its filetype
+plugins load, run the operation, print, quit:
+
+```bash
+source ~/.nvim-sandbox.env
+nvim --headless path/to/file.go \
+  -c '<command that performs the operation, e.g. runs the formatter>' \
+  -c 'lua io.write(table.concat(vim.fn.getline(1, "$"), "\n").."\n")' \
+  -c 'qa!'
+```
+
+`-c` commands run in order after startup. Opening a file fires `FileType`
+loading, but a plugin that lazy-loads on its *own* event or command only
+activates once you invoke that command — so trigger the real operation rather
+than assuming the plugin is already loaded.
+
 ## Testing a config-change PR
 
 The `nvim-fredrik` config is part of *this* repo, so a PR that changes it is


### PR DESCRIPTION
## Why?

Running the "Testing a config-change PR" restart flow end to end in a web sandbox exposed two bugs, both from reusing the fixed `$NVIM` socket path on restart:

- **`pkill` self-match.** `pkill -f 'nvim --headless --listen'` (introduced in the previous PR as a "reliability" fix) matches the script's *own* shell — the harness runs each Bash call as `bash -c '<script>'`, so that literal string is in the shell's arguments. pkill kills the script itself, which dies with a `128 + signal` exit (e.g. `143`/`144`) before nvim ever relaunches.
- **Socket-cleanup race.** A dying nvim unlinks its own socket on exit, so relaunching on the same path before the old instance is gone lets its cleanup delete the *new* socket. RPC then fails with `connection refused` while the new process is alive. It's timing-dependent, so it fails intermittently.

Separately, the skill only documented the persistent `--listen` + cross-turn RPC path. Many tasks are observe-once and don't need it — and that heavier path is where the footguns live.

## What?

- Record the launch PID to `/tmp/nvim-fredrik.pid` in Step 4.
- On restart, kill that exact PID and wait until it is confirmed gone (SIGKILL fallback) before `rm`-ing the socket path and relaunching.
- Expand the restart prose to explain both traps.
- Add a **"One-shot checks"** section: for observe-once tasks, use a self-terminating headless run (`nvim --headless … -c 'qa!'`) that loads the real config, exercises it, prints, and quits — no socket, no restart, no footguns. Reserve the persistent server for genuinely interactive debugging.

```bash
# before — self-matches the script's own `bash -c` shell, kills the script:
pkill -f 'nvim --headless --listen' 2>/dev/null || true

# after — kill the recorded PID and wait for it to exit before reusing $NVIM:
oldpid="$(cat /tmp/nvim-fredrik.pid 2>/dev/null)"
if [ -n "$oldpid" ]; then
  kill "$oldpid" 2>/dev/null || true
  for i in $(seq 1 50); do kill -0 "$oldpid" 2>/dev/null || break; sleep 0.2; done
  kill -9 "$oldpid" 2>/dev/null || true
fi
```

## Notes

- Verified in-sandbox: repeated restarts each yield a working RPC socket and the script always runs to completion; the one-shot config-load run exits `0` with no errors. Confirmed the `pkill -f` pattern matches the running script's own shell via `pgrep`, and reproduced the socket race (`connection refused` → socket file gone while the process stayed alive).
- Also confirmed the companion `neovim` RPC skill needs no change — it only *consumes* `$NVIM` via `--server`; it never launches or `pkill`s nvim, so the pattern appears in exactly one committed place (this skill).