### PR TITLE
fix(nvim): fall back to GitHub when local plugin checkout is absent

### DIFF
--- a/nvim-fredrik/plugin/neotest.lua
+++ b/nvim-fredrik/plugin/neotest.lua
@@ -1,5 +1,10 @@
 require("lazyload").on_vim_enter(function()
-  require("dev").load_local("~/code/public/neotest-golang")
+  -- neotest-golang: load from disk if checked out locally, otherwise from GitHub.
+  if not require("dev").load_local("~/code/public/neotest-golang") then
+    vim.pack.add({
+      { src = "https://github.com/fredrikaverpil/neotest-golang" },
+    })
+  end
 
   vim.pack.add({
     { src = "https://github.com/nvim-neotest/neotest", version = vim.version.range("*") },
@@ -12,8 +17,6 @@ require("lazyload").on_vim_enter(function()
     { src = "https://github.com/nvim-neotest/neotest-python" },
     { src = "https://github.com/lawrence-laz/neotest-zig" },
 
-    -- neotest-golang
-    -- { src = "https://github.com/fredrikaverpil/neotest-golang" },
     { src = "https://github.com/uga-rosa/utf8.nvim" },
   })
 

--- a/nvim-fredrik/plugin/neotest.lua
+++ b/nvim-fredrik/plugin/neotest.lua
@@ -17,6 +17,7 @@ require("lazyload").on_vim_enter(function()
     { src = "https://github.com/nvim-neotest/neotest-python" },
     { src = "https://github.com/lawrence-laz/neotest-zig" },
 
+    -- neotest-golang dependency (the adapter itself is loaded above)
     { src = "https://github.com/uga-rosa/utf8.nvim" },
   })
 

--- a/nvim-fredrik/plugin/pr.lua
+++ b/nvim-fredrik/plugin/pr.lua
@@ -1,8 +1,10 @@
 require("lazyload").on_vim_enter(function()
-  require("dev").load_local("~/code/public/pr.nvim")
-  vim.pack.add({
-    -- { src = "https://github.com/fredrikaverpil/pr.nvim" },
-  })
+  -- Load from disk if checked out locally, otherwise from GitHub.
+  if not require("dev").load_local("~/code/public/pr.nvim") then
+    vim.pack.add({
+      { src = "https://github.com/fredrikaverpil/pr.nvim" },
+    })
+  end
 
   require("pr").setup({})
 


### PR DESCRIPTION
## Why?

- `plugin/neotest.lua` and `plugin/pr.lua` called `dev.load_local()` unconditionally with the GitHub `src` commented out.
- `dev.load_local()` returns `false` when the path is missing, but neither file used that return, so on any machine without the local `~/code/public` checkout the plugin never loaded — and the subsequent `require()` errored:

```lua
-- before (pr.lua): load_local runs, GitHub source is dead-commented
require("dev").load_local("~/code/public/pr.nvim")
vim.pack.add({
  -- { src = "https://github.com/fredrikaverpil/pr.nvim" },
})
require("pr").setup({})  -- errors when ~/code/public/pr.nvim is absent
```

## What?

- Use `load_local()`'s boolean return for the disk-first / GitHub-fallback pattern in both files:

```lua
if not require("dev").load_local("~/code/public/pr.nvim") then
  vim.pack.add({ { src = "https://github.com/fredrikaverpil/pr.nvim" } })
end
```

- Same change for `neotest-golang` in `plugin/neotest.lua`, plus a comment noting `utf8.nvim` is its dependency.

## Notes

- Verified in a headless Neovim (nixpkgs-unstable, v0.12.4) with the local checkouts absent: both `neotest-golang` and `pr.nvim` cloned from GitHub, `require()` resolved, and their keymaps registered.
- `plugin/lang/go.lua` (godoc) and `plugin/codediff.lua` are unaffected — they already have a working source; converting them to the same idiom is an optional follow-up.
