### PR TITLE
fix(rpi5-homelab): keep remote-control server alive across boot

### DIFF
--- a/nix/hosts/rpi5-homelab/configuration.nix
+++ b/nix/hosts/rpi5-homelab/configuration.nix
@@ -53,6 +53,11 @@ in {
     };
   };
 
+  # Enable systemd linger for fredrik so user services (e.g. the Claude Code
+  # remote-control server) start on boot and keep running without an
+  # interactive login session.
+  users.users.fredrik.linger = true;
+
   # Wireless network configuration
   # Use NetworkManager with wpa_supplicant backend for better Pi stability under load
   networking.wireless.iwd.enable = false; # Disable iwd (less stable on Pi under load)

--- a/nix/hosts/rpi5-homelab/users/fredrik.nix
+++ b/nix/hosts/rpi5-homelab/users/fredrik.nix
@@ -32,8 +32,9 @@ in
   systemd.user.services.claude-code-server = {
     Unit = {
       Description = "Claude Code Remote Control Server";
-      After = [ "network-online.target" ];
-      Wants = [ "network-online.target" ];
+      # No network-online.target dependency: user services cannot meaningfully
+      # order against that system target, and it can stall boot on WiFi ARM
+      # hosts. Restart=always below reconnects once the network is up.
     };
 
     Service = {


### PR DESCRIPTION
## Why?

- The `claude remote-control` server (systemd **user** service `claude-code-server`) kept going offline: it stopped on logout and did not start on boot.
- Root cause: the user manager did not persist without an interactive login, so `WantedBy = default.target` never fired at boot.

## What?

- Enable systemd linger for `fredrik` so the user manager starts at boot and keeps user services running without a login session ([configuration.nix:59](https://github.com/fredrikaverpil/dotfiles/blob/0db0109c90d1b0f0c6fa9f92bfd8fa9e6de33de3/nix/hosts/rpi5-homelab/configuration.nix#L59)):

  ```nix
  users.users.fredrik.linger = true;
  ```

- Drop the `network-online.target` `After`/`Wants` from the user unit ([fredrik.nix:35](https://github.com/fredrikaverpil/dotfiles/blob/0db0109c90d1b0f0c6fa9f92bfd8fa9e6de33de3/nix/hosts/rpi5-homelab/users/fredrik.nix#L35)). A user service cannot meaningfully order against that system target (it is inert in the per-user manager) and it can stall boot on WiFi ARM hosts. `Restart = "always"` already reconnects once the network is up.

## Notes

- Expect benign restart-looping in the journal on cold boot until WiFi associates (~10s cadence); safe from systemd's start-rate limiter given `RestartSec = "10"`.
- Apply with `nixos-rebuild switch`; linger takes effect on next boot (or immediately via `loginctl enable-linger fredrik`).