### PR TITLE
feat(rpi5-homelab): run opencode headless server on boot

### DIFF
--- a/nix/hosts/rpi5-homelab/users/fredrik.nix
+++ b/nix/hosts/rpi5-homelab/users/fredrik.nix
@@ -59,4 +59,71 @@ in
       WantedBy = [ "default.target" ];
     };
   };
+
+  # OpenCode headless server service
+  # Runs automatically on boot, mirroring the Claude Code remote-control server
+  # above but for a provider-agnostic agent (OpenRouter etc.).
+  #
+  # Reachability: binds 0.0.0.0 but is *not* added to networking.firewall
+  # allowedTCPPorts, so the local network is blocked while the trusted
+  # "tailscale+" interface (see configuration.nix) passes. Net effect:
+  # reachable over Tailscale only, at http://rpi5-homelab:4096. Because the
+  # process binds 0.0.0.0, that firewall allowlist is the only LAN barrier:
+  # do NOT add port 4096 to allowedTCPPorts, or Basic auth would be exposed
+  # over cleartext HTTP on the local network.
+  #
+  # Auth: OpenCode's HTTP Basic auth is enabled *by the presence of*
+  # OPENCODE_SERVER_PASSWORD, supplied out-of-band via EnvironmentFile
+  # (mirrors the restic.nix secret convention) and never tracked in git. The
+  # unit fails closed on both a missing and an empty secret: EnvironmentFile
+  # without a leading "-" fails the unit if the file is absent, and the
+  # ${OPENCODE_SERVER_PASSWORD:?...} guard in ExecStart refuses to start if
+  # the variable is unset or empty. Without that guard an empty file would
+  # start an unauthenticated server, which for an agent that can run host
+  # commands is effectively tailnet-wide RCE. Create the secret atomically
+  # (single write, never an empty intermediate state) once on the host:
+  #   ( umask 077; printf 'OPENCODE_SERVER_PASSWORD=%s\n' \
+  #       "$(openssl rand -base64 24)" > ~/.config/opencode/server.env )
+  # and log in to a provider once with: opencode auth login
+  #
+  # Working directory: ~/code/public
+  systemd.user.services.opencode-server = {
+    Unit = {
+      Description = "OpenCode Headless Server";
+      # No network-online.target dependency: user services cannot meaningfully
+      # order against that system target, and it can stall boot on WiFi ARM
+      # hosts. Restart=always below reconnects once the network is up.
+    };
+
+    Service = {
+      Type = "simple";
+      WorkingDirectory = "%h/code/public";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/code/public";
+      # The ${OPENCODE_SERVER_PASSWORD:?...} guard fails the unit closed when
+      # the secret is unset or empty, so the server never comes up without
+      # Basic auth (see the auth note above).
+      ExecStart = "${pkgs.bash}/bin/bash -c ': \"\${OPENCODE_SERVER_PASSWORD:?set OPENCODE_SERVER_PASSWORD in server.env}\"; exec $HOME/.nix-profile/bin/opencode serve --hostname 0.0.0.0 --port 4096 --print-logs'";
+      Restart = "always";
+      RestartSec = "10";
+
+      # HTTP Basic auth secret (OPENCODE_SERVER_PASSWORD), supplied out-of-band
+      # and not tracked in git. No leading "-": the file is required, so an
+      # absent secret fails the unit; the ExecStart guard additionally covers
+      # a present-but-empty secret.
+      EnvironmentFile = "%h/.config/opencode/server.env";
+
+      # Logging
+      StandardOutput = "journal";
+      StandardError = "journal";
+
+      # Environment
+      Environment = [
+        "PATH=%h/.nix-profile/bin:${lib.makeBinPath [ pkgs.git pkgs.coreutils pkgs.findutils pkgs.gnugrep pkgs.gnused pkgs.gawk ]}"
+      ];
+    };
+
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 }


### PR DESCRIPTION
## Why?

- The Pi already hosts a [`claude-code-server`](https://github.com/fredrikaverpil/dotfiles/blob/4f17b0750eb68ab580a6cc437c73187ab312b441/nix/hosts/rpi5-homelab/users/fredrik.nix#L32) remote-control unit that is reachable from the iOS app — near-perfect, except it locks work to Anthropic models.
- [OpenCode](https://opencode.ai) (already installed via the [`llm-agents.nix`](https://github.com/numtide/llm-agents.nix) flake input) is provider-agnostic, so hosting its headless server the same way unlocks OpenRouter-routed models (cheap model for routine work, stronger model for review) while keeping the same phone-client workflow.

## What?

- Add a `systemd.user.services.opencode-server` unit in [`fredrik.nix:90`](https://github.com/fredrikaverpil/dotfiles/blob/4f17b0750eb68ab580a6cc437c73187ab312b441/nix/hosts/rpi5-homelab/users/fredrik.nix#L90), mirroring the Claude unit (`Type=simple`, `Restart=always`, journal logging, `WorkingDirectory=~/code/public`, `WantedBy=default.target`).
- Run `opencode serve --hostname 0.0.0.0 --port 4096 --print-logs`.
- Enable HTTP Basic auth via `OPENCODE_SERVER_PASSWORD`, sourced from an `EnvironmentFile` (`~/.config/opencode/server.env`) kept out of git — same pattern as [`restic.nix`](https://github.com/fredrikaverpil/dotfiles/blob/4f17b0750eb68ab580a6cc437c73187ab312b441/nix/hosts/rpi5-homelab/restic.nix#L14).

## Notes

- **Tailscale-only, no firewall change.** The port is intentionally not added to `networking.firewall.allowedTCPPorts`, so the local network is blocked while the trusted `tailscale+` interface passes. Reachable at `http://rpi5-homelab:4096` over the tailnet (MagicDNS name) — **not** on the plain LAN / `.local`.
- **Fails closed on missing *and* empty secret.** `EnvironmentFile` has no leading `-` (missing file fails the unit), and a `${OPENCODE_SERVER_PASSWORD:?…}` guard in `ExecStart` refuses to start when the variable is unset or empty — so the agent server never comes up unauthenticated. (Fix from Opus review: without the guard, the empty-file window in the setup recipe would have exposed an unauthenticated, host-command-capable server on the tailnet.)
- **One-time host setup** (not in this PR): create `~/.config/opencode/server.env` atomically with `OPENCODE_SERVER_PASSWORD`, and run `opencode auth login` for the OpenRouter provider. Steps are documented inline in the unit comment.
- Verified with `nixos-rebuild dry-build` (exit 0); the unit evaluates as `opencode-server.service.drv`. Not yet activated on the host.