### PR TITLE
feat(darwin): install Tailscale on macOS hosts

### DIFF
--- a/nix/shared/system/darwin.nix
+++ b/nix/shared/system/darwin.nix
@@ -107,6 +107,7 @@ in
         "signal"
         "slack"
         "spotify"
+        "tailscale-app"
         "visual-studio-code"
         "wacom-tablet"
         "wezterm"


### PR DESCRIPTION
## Why?

- Macs need to join the tailnet to reach Tailscale-only homelab services — notably the [opencode server](https://github.com/fredrikaverpil/dotfiles/pull/207) on `rpi5-homelab`, which is deliberately not exposed on the LAN.
- Installing it declaratively keeps macOS hosts reproducible instead of a manual [Tailscale](https://tailscale.com) download.

## What?

- Add the [`tailscale-app`](https://formulae.brew.sh/cask/tailscale-app) Homebrew cask to the shared darwin casks list ([`darwin.nix:110`](https://github.com/fredrikaverpil/dotfiles/blob/c41a0a00bacd2654bd26fb7df310539020a6f2df/nix/shared/system/darwin.nix#L110)), so it installs on all macOS hosts.

## Notes

- Uses the **GUI menu-bar app** (`tailscale-app` cask), not the headless CLI daemon — the browser sign-in and macOS network extension are the better fit for a laptop. The former `tailscale` token now refers to the open-source CLI/daemon formula.
- One-time manual step per host: sign in via the menu-bar app (`tailscale up`) to join the tailnet. MagicDNS then resolves `rpi5-homelab`, so `opencode attach http://rpi5-homelab:4096` works from the Mac.
- Not built/activated from here — a darwin config can't be evaluated on the Linux Pi; rebuild on the Mac (`darwin-rebuild switch`). The change is a one-line addition to the existing alphabetized cask list (parses clean).