### PR TITLE
chore(rpi5-homelab): disable Immich restic backup

### DIFF
--- a/nix/hosts/rpi5-homelab/restic.nix
+++ b/nix/hosts/rpi5-homelab/restic.nix
@@ -3,7 +3,13 @@
   pkgs,
   lib,
   ...
-}: {
+}:
+let
+  # Toggle the Immich restic backup and validation on/off.
+  # Set to true to re-enable the weekly offsite backup + validation.
+  enable = false;
+in
+lib.mkIf enable {
   # Restic backup configuration for Immich (backup only)
   services.restic = {
     backups = {
@@ -39,14 +45,31 @@
   };
 
   # Add required packages to the restic backup service PATH
-  systemd.services.restic-backups-immich.path = with pkgs; [docker gzip curl coreutils gnugrep openssh];
+  systemd.services.restic-backups-immich.path = with pkgs; [
+    docker
+    gzip
+    curl
+    coreutils
+    gnugrep
+    openssh
+  ];
 
   # Separate validation service
   systemd.services.restic-validation-immich = {
     description = "Immich Backup Validation";
-    after = ["network-online.target"];
-    wants = ["network-online.target"];
-    path = with pkgs; [docker curl gzip restic coreutils util-linux gnugrep gnused openssh];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    path = with pkgs; [
+      docker
+      curl
+      gzip
+      restic
+      coreutils
+      util-linux
+      gnugrep
+      gnused
+      openssh
+    ];
     serviceConfig = {
       Type = "oneshot";
       User = "root";
@@ -59,7 +82,7 @@
   # Validation timer (runs 30 minutes after backup)
   systemd.timers.restic-validation-immich = {
     description = "Timer for Immich Backup Validation";
-    wantedBy = ["timers.target"];
+    wantedBy = [ "timers.target" ];
     timerConfig = {
       OnCalendar = "Sun 03:30";
       Persistent = true;


### PR DESCRIPTION
## Why?

- Immich is no longer used for primary family photo storage — it's kept running only experimentally.
- The weekly offsite [restic](https://restic.net/) backup and its validation run are no longer needed.

## What?

- Gate the entire Immich restic module behind a local `enable` boolean (default `false`), wrapped in [`lib.mkIf`](https://nixos.org/manual/nixpkgs/stable/#function-library-lib.trivial.mkIf), in [restic.nix:7-12](https://github.com/fredrikaverpil/dotfiles/blob/ab7ce195bbc1c1224a05c4287d8dad59bd79df14/nix/hosts/rpi5-homelab/restic.nix#L7-L12).
- Disables the backup service/timer (`Sun 03:00`), the validation service/timer (`Sun 03:30`), and the `/etc/homelab/scripts/*` installs.

```nix
let
  enable = false; # flip to true to re-enable
in
lib.mkIf enable { ... }
```

## Notes

- Immich itself is untouched (defined in `docker-compose/immich.yml`) — it keeps running, just unbackedup.
- Existing snapshots on Hetzner and `/etc/restic/*` secrets are left in place.
- Not yet applied on the host; needs a `nixos-rebuild switch`.