### PR TITLE
feat(rpi5-homelab): add WiFi connectivity watchdog

### DIFF
--- a/nix/hosts/rpi5-homelab/configuration.nix
+++ b/nix/hosts/rpi5-homelab/configuration.nix
@@ -75,6 +75,83 @@ in {
     ACTION=="add", SUBSYSTEM=="net", KERNEL=="wlan*", RUN+="${pkgs.iw}/bin/iw dev $name set power_save off"
   '';
 
+  # WiFi watchdog: reconnects wlan if NM reports it disconnected, or if it
+  # appears connected but pings to the default gateway fail. Escalates to a
+  # brcmfmac driver reload if nmcli connect fails (targets the "never recovered"
+  # wedged-driver case documented in https://github.com/fredrikaverpil/dotfiles/issues/204).
+  systemd.services.wifi-watchdog = {
+    description = "WiFi connectivity watchdog";
+    after = ["network-online.target"];
+    wants = ["network-online.target"];
+    serviceConfig = {
+      Type = "oneshot";
+      # Budget: ping(15s) + sleep(3s) + nmcli-connect(30s) + driver-reload(5s) +
+      # nmcli-connect-retry(30s) = ~83s worst case; 120s gives comfortable headroom.
+      TimeoutStartSec = "120s";
+      ExecStart = pkgs.writeShellScript "wifi-watchdog" ''
+        # Use nmcli for interface discovery to avoid picking up p2p-dev-wlan0
+        iface=$(${pkgs.networkmanager}/bin/nmcli -t -f DEVICE,TYPE device | \
+                ${pkgs.gawk}/bin/awk -F: '$2=="wifi"{print $1; exit}')
+        [ -z "$iface" ] && exit 0
+
+        reconnect() {
+          echo "wifi-watchdog: reconnecting $iface..."
+          ${pkgs.networkmanager}/bin/nmcli device disconnect "$iface" || true
+          ${pkgs.coreutils}/bin/sleep 3
+          # --wait 30 bounds the blocking connect so it always returns within budget.
+          if ! ${pkgs.networkmanager}/bin/nmcli --wait 30 device connect "$iface"; then
+            # nmcli connect failed — escalate to driver reload to recover a wedged
+            # brcmfmac, which nmcli retries alone cannot fix.
+            echo "wifi-watchdog: nmcli connect failed, reloading brcmfmac driver..."
+            ${pkgs.kmod}/bin/modprobe -r brcmfmac || true
+            ${pkgs.coreutils}/bin/sleep 2
+            ${pkgs.kmod}/bin/modprobe brcmfmac || true
+            ${pkgs.coreutils}/bin/sleep 3
+            if ! ${pkgs.networkmanager}/bin/nmcli --wait 30 device connect "$iface"; then
+              echo "wifi-watchdog: reconnect after driver reload failed, will retry on next tick"
+            fi
+          fi
+        }
+
+        state=$(${pkgs.networkmanager}/bin/nmcli -g GENERAL.STATE device show "$iface" 2>/dev/null)
+        state_code="''${state%% *}"
+
+        # NM device state codes: 100=connected, 40-90=connecting (leave alone),
+        # everything else (0/10/20/30/110/120) = reconnect.
+        case "$state_code" in
+          100)
+            # Connected — verify actual reachability via ping
+            gateway=$(${pkgs.iproute2}/bin/ip route show dev "$iface" | \
+                      ${pkgs.gawk}/bin/awk '/default/{print $3; exit}')
+            [ -z "$gateway" ] && exit 0
+            if ! ${pkgs.iputils}/bin/ping -c 3 -W 5 -I "$iface" "$gateway" >/dev/null 2>&1; then
+              echo "wifi-watchdog: no ping response on $iface, reconnecting..."
+              reconnect
+            fi
+            ;;
+          4*|5*|6*|7*|8*|9*)
+            # Association in progress — leave alone
+            echo "wifi-watchdog: $iface connecting (state: $state), skipping"
+            ;;
+          *)
+            # Disconnected, unavailable, failed, or unknown
+            echo "wifi-watchdog: $iface not connected (state: $state), reconnecting..."
+            reconnect
+            ;;
+        esac
+      '';
+    };
+  };
+
+  systemd.timers.wifi-watchdog = {
+    description = "WiFi watchdog timer";
+    wantedBy = ["timers.target"];
+    timerConfig = {
+      OnBootSec = "2min";
+      OnUnitActiveSec = "1min";
+    };
+  };
+
   # Firewall configuration for homelab services
   # NOTE: for maximum security, do not expose SSH to internet, only via Tailscale VPN
   networking.firewall = {


### PR DESCRIPTION
## Why?

- NetworkManager's built-in autoconnect recovers most WiFi drops, but certain failure modes (NM stuck, `brcmfmac` driver wedge) leave the interface silent or disconnected with no recovery
- The Pi is accessed exclusively over Tailscale/WiFi — undetected drops cause the host to go dark until a reboot
- The original "never recovered" symptom (#204) points specifically to a wedged driver that NM-level retries alone can't fix

## What?

- Add `systemd.timers.wifi-watchdog` + `systemd.services.wifi-watchdog` to `nix/hosts/rpi5-homelab/configuration.nix`
- Every minute, checks NM device state by numeric code and pings the default gateway over the wlan interface
- Three paths based on NM state code:
  - `100` (connected): ping the gateway; reconnect if all pings fail
  - `40-90` (connecting in progress): skip — avoids tearing down a legitimate association
  - anything else (disconnected/failed/unavailable): reconnect immediately
- Reconnect escalation:
  1. `nmcli device disconnect` + `nmcli --wait 30 device connect`
  2. If that fails: `modprobe -r brcmfmac && modprobe brcmfmac` + retry connect — directly targets the wedged-driver case
- `TimeoutStartSec=120s` covers the full escalation path (ping 15s + connect 30s + reload 5s + retry 30s ≈ 83s)

```nix
systemd.services.wifi-watchdog = {
  serviceConfig = {
    Type = "oneshot";
    TimeoutStartSec = "120s";
    ExecStart = pkgs.writeShellScript "wifi-watchdog" ''
      # ...
      reconnect() {
        nmcli device disconnect "$iface" || true
        sleep 3
        if ! nmcli --wait 30 device connect "$iface"; then
          modprobe -r brcmfmac || true && sleep 2
          modprobe brcmfmac || true && sleep 3
          nmcli --wait 30 device connect "$iface" || echo "retry on next tick"
        fi
      }
      case "$state_code" in
        100)     ping gateway || reconnect ;;
        4*|..9*) skip ;;
        *)       reconnect ;;
      esac
    '';
  };
};
```

## Notes

- All binaries use full `${pkgs.*}/bin/` paths — systemd's default PATH only contains its own bindir
- Interface discovery uses `nmcli -t -f DEVICE,TYPE` to avoid matching `p2p-dev-wlan0`
- State matched on numeric code (`${state%% *}`) — substring matching on the label matches "disconnected" inside "connected"
- `nmcli --wait 30` bounds the blocking call so a SIGKILL can't land after disconnect but before connect (which would leave autoconnect suppressed)
- Complements the existing udev rule that disables WiFi power saving on `wlan*` interfaces

Closes #204