### PR TITLE
feat(rpi5-homelab): restart agent services on home-manager activation

### DIFF
--- a/nix/hosts/rpi5-homelab/users/fredrik.nix
+++ b/nix/hosts/rpi5-homelab/users/fredrik.nix
@@ -26,6 +26,13 @@ in
   programs = {
   };
 
+  # Restart agent services after every activation so the running binary
+  # matches the version installed by the latest rebuild.
+  home.activation.restartAgentServices = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD systemctl --user restart claude-code-server.service || true
+    $DRY_RUN_CMD systemctl --user restart opencode-server.service || true
+  '';
+
   # Claude Code remote-control server service
   # Runs automatically on boot, accessible via remote-control protocol
   # Working directory: ~/code/public


### PR DESCRIPTION
## Why?

- `claude-code-server` and `opencode-server` both resolve their binary via `$HOME/.nix-profile/bin/<name>` (a symlink), not a Nix store path
- When `nixos-rebuild switch` updates a package, the symlink changes but the systemd unit text doesn't — NixOS activation doesn't detect a unit change and leaves the old binary running

## What?

- Add `home.activation.restartAgentServices` to `rpi5-homelab/users/fredrik.nix`, ordering it after `writeBoundary` so unit files and `daemon-reload` are already done
- Restarts both `claude-code-server.service` and `opencode-server.service`
- Uses `$DRY_RUN_CMD` for dry-run support; `|| true` avoids activation failure on first boot before the services exist

```nix
home.activation.restartAgentServices = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
  $DRY_RUN_CMD systemctl --user restart claude-code-server.service || true
  $DRY_RUN_CMD systemctl --user restart opencode-server.service || true
'';
```