### PR TITLE
fix(nix): pin docker_29 to unblock eval on nixos-25.11

### DIFF
--- a/nix/hosts/rpi5-homelab/configuration.nix
+++ b/nix/hosts/rpi5-homelab/configuration.nix
@@ -182,6 +182,11 @@ in {
   # Docker containerization platform
   virtualisation.docker = {
     enable = true;
+    # Pinned explicitly: on nixos-25.11 the `pkgs.docker` alias still points at
+    # docker_28, which that same nixpkgs marks insecure (unmaintained since
+    # November 2025), so the module default refuses to evaluate.
+    # Drop this pin once upstream moves the alias -- see issue #212.
+    package = pkgs.docker_29;
   };
 
   # Host-specific system users

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -144,7 +144,12 @@ in
       jujutsu
       lazygit
       lazydocker
-      docker-client # Docker CLI only (no engine); routes to whatever DOCKER_HOST points at
+      # Docker CLI only (no engine); routes to whatever DOCKER_HOST points at.
+      # Built from docker_29 rather than the `docker-client` alias: that alias
+      # derives from `pkgs.docker`, which on nixos-25.11 is still docker_28 and
+      # is marked insecure there (unmaintained since November 2025).
+      # Drop this pin once upstream moves the alias -- see issue #212.
+      (docker_29.override { clientOnly = true; })
 
       # ========================================================================
       # Network, API & Database


### PR DESCRIPTION
## Why?

- [`nixos-25.11`](https://github.com/NixOS/nixpkgs/tree/nixos-25.11) is internally inconsistent: it marks `docker_28` insecure (`unmaintained since November 2025, use docker_29 or newer`) while `all-packages.nix` still has `docker = docker_28;`. Any reference to `pkgs.docker` therefore refuses to evaluate.
- Reached `rpi5-homelab` via 99465526, which bumped [`nixos-raspberrypi`](https://github.com/nvmd/nixos-raspberrypi) `06c6e35` → `c845922` and with it the nixpkgs it pins, `d7a713c` → `b6018f8`.
- Broke CI on `main`: [run 30466613761](https://github.com/fredrikaverpil/dotfiles/actions/runs/30466613761). `nixos-rebuild` on the Pi fails the same way — at eval, so the running system is never touched.

The failing case:

```console
$ nix flake check --accept-flake-config
error: Package ‘docker-28.5.2’ is marked as insecure, refusing to evaluate.
  Known issues:
   - docker_28 has been unmaintained since November 2025, use docker_29 or newer instead
```

## What?

- [nix/hosts/rpi5-homelab/configuration.nix:186](https://github.com/fredrikaverpil/dotfiles/blob/bd2f963bad80a6cc3316060fbb3f02998670e692/nix/hosts/rpi5-homelab/configuration.nix#L186) — pin `virtualisation.docker.package = pkgs.docker_29;`
- [nix/shared/home/common.nix:149](https://github.com/fredrikaverpil/dotfiles/blob/bd2f963bad80a6cc3316060fbb3f02998670e692/nix/shared/home/common.nix#L149) — `docker-client` → `(docker_29.override { clientOnly = true; })`

Two call sites, because [`docker-client`](https://github.com/NixOS/nixpkgs/blob/b6018f87da91d19d0ab4cf979885689b469cdd41/pkgs/top-level/all-packages.nix#L10822) derives from the same poisoned alias:

```nix
docker = docker_28;                                  # marked insecure
docker-client = docker.override { clientOnly = true; };  # inherits the problem
```

## Notes

- **Pinned rather than reverting the lockfile.** The `nixos-25.11` branch head has not moved since 2026-06-30 and `nixos-raspberrypi` HEAD is already the locked rev — there is nothing newer to move to, so the next `nix flake update` would walk straight back into it. A revert would also roll back the Pi kernel/firmware pin.
- macOS hosts are unaffected (they track `nixpkgs-unstable`, where the alias already moved to `docker_29`), but `common.nix` is shared — verified `docker_29.override { clientOnly = true; }` evaluates on `aarch64-darwin` (29.6.2).
- Verified on the Pi: failure reproduced at 99465526, then `nix flake check` passes and the full system closure builds. Closure contains `docker-29.6.0` and zero `docker-28` references.
- `docker_29` is prebuilt in `cache.nixos.org` for aarch64 — no source build.
- Unpin tracked in #212.
