### PR TITLE
Drop the docker_29 pins by moving to nixpkgs 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,16 +130,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -241,11 +241,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783459375,
-        "narHash": "sha256-S2pb+Mtv0qTeRr+6J5ESgelNjG2YKl4WqKjdPrJx5rM=",
+        "lastModified": 1785596452,
+        "narHash": "sha256-KT/OleUMpSKsWgi0eTuqS/0GD4ucPQcvLgmvlw8ZuCM=",
         "owner": "nvmd",
         "repo": "nixos-raspberrypi",
-        "rev": "c845922f260b306d4529a4535bbb6e7f8cfe2887",
+        "rev": "7e39508bcf9c1da82cf11c1e22f74f9d9fd0fe10",
         "type": "github"
       },
       "original": {
@@ -289,16 +289,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
       # NOTE: The branch must match the release of nixos-raspberrypi's pinned
       # nixpkgs (check `nixpkgs.original.ref` under the nixos-raspberrypi node
       # in flake.lock). Bump this branch when updating nixos-raspberrypi.
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixos-raspberrypi/nixpkgs";
     };
     home-manager-unstable = {

--- a/nix/hosts/rpi5-homelab/configuration.nix
+++ b/nix/hosts/rpi5-homelab/configuration.nix
@@ -182,11 +182,6 @@ in {
   # Docker containerization platform
   virtualisation.docker = {
     enable = true;
-    # Pinned explicitly: on nixos-25.11 the `pkgs.docker` alias still points at
-    # docker_28, which that same nixpkgs marks insecure (unmaintained since
-    # November 2025), so the module default refuses to evaluate.
-    # Drop this pin once upstream moves the alias -- see issue #212.
-    package = pkgs.docker_29;
   };
 
   # Host-specific system users

--- a/nix/shared/home/common.nix
+++ b/nix/shared/home/common.nix
@@ -144,12 +144,7 @@ in
       jujutsu
       lazygit
       lazydocker
-      # Docker CLI only (no engine); routes to whatever DOCKER_HOST points at.
-      # Built from docker_29 rather than the `docker-client` alias: that alias
-      # derives from `pkgs.docker`, which on nixos-25.11 is still docker_28 and
-      # is marked insecure there (unmaintained since November 2025).
-      # Drop this pin once upstream moves the alias -- see issue #212.
-      (docker_29.override { clientOnly = true; })
+      docker-client # Docker CLI only (no engine); routes to whatever DOCKER_HOST points at
 
       # ========================================================================
       # Network, API & Database


### PR DESCRIPTION
## Why?

- [#212](https://github.com/fredrikaverpil/dotfiles/issues/212) pinned `docker_29` in two places because `nixos-25.11` was internally inconsistent: it marked `docker_28` insecure while still aliasing `docker` to it, so anything touching `pkgs.docker` refused to evaluate.
- The unpin condition in that issue is now met — but not by `nixos-25.11` fixing itself. [nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi) release [v1.20260801.0](https://github.com/nvmd/nixos-raspberrypi/releases/tag/v1.20260801.0) moved its pinned nixpkgs onto `nixos-26.05`, where the alias is already `docker_29`.

## What?

- Bump `nixos-raspberrypi` `c845922` → `7e39508`, moving `rpi5-homelab` from nixpkgs 25.11 to 26.05.
- Bump `home-manager-rpi` to `release-26.05` in lockstep, as the note on that input requires: [flake.nix:52](https://github.com/fredrikaverpil/dotfiles/blob/61cb8372462ee5a2cc02f2908f0b916084c3160e/flake.nix#L52).
- Revert both pins to their pre-pin form: [configuration.nix:183](https://github.com/fredrikaverpil/dotfiles/blob/61cb8372462ee5a2cc02f2908f0b916084c3160e/nix/hosts/rpi5-homelab/configuration.nix#L183) and [common.nix:147](https://github.com/fredrikaverpil/dotfiles/blob/61cb8372462ee5a2cc02f2908f0b916084c3160e/nix/shared/home/common.nix#L147).

Both call sites now land on the same package the pins were forcing:

```console
$ nix eval .#nixosConfigurations.rpi5-homelab.pkgs.docker.name
docker-29.6.2
$ nix eval .#nixosConfigurations.rpi5-homelab.pkgs.docker-client.name
docker-29.6.2
```

## Notes

- CI green on all three hosts. `nix flake check --accept-flake-config` passes locally, so eval-level 26.05 breakage is ruled out. The two commits are split so each stands alone; the bump commit was verified to still evaluate with the pins in place.
- **Kernel and firmware are unchanged** — `6.18.34-unstable_20260604` before and after, matching the release notes ("kernel `6.18.34`, firmware `1.20260521`"). The 25.11 → 26.05 move is userspace only.
- `system.stateVersion` stays at `25.05`, satisfying the release's migration note. It must not be bumped.
- **Activation risk — wifi.** 26.05 changes NetworkManager to drive `networking.wireless` instead of spawning its own `wpa_supplicant`. On this config that flips a computed default:

  | | 25.11 | 26.05 |
  |---|---|---|
  | `networking.wireless.enable` | `false` | `true` |
  | `networking.wireless.enableHardening` | n/a | `true` |
  | systemd units | none | `wpa_supplicant.service` |

  So `wlan0` gets re-established by a new, unprivileged `wpa_supplicant.service` rather than an NM-internal one. Inspecting the generated unit, this is wired correctly for this setup and is expected to be transparent:

  ```
  wpa_supplicant -s -u -Dnl80211,wext -c /etc/wpa_supplicant/imperative.conf
  ```

  - `-u` (D-Bus control interface) with no `-i` is exactly the mode NetworkManager drives; NM keeps holding the credentials, so nothing needs migrating.
  - `ExecStartPre` creates `imperative.conf` and chowns it plus `/etc/wpa_supplicant` to the new `wpa_supplicant` user; `RuntimeDirectory=wpa_supplicant` covers the `ctrl_interface` permission caveat from the release notes (which only bites if `ctrl_interface` is overridden in `extraConfig` — it isn't here).
  - `AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW` retains the needed caps after dropping root; `wantedBy=multi-user.target` starts it at boot.

  Flagged for blast radius rather than likelihood: this host is wifi-only (`end0` down, default route and Tailscale both on `wlan0`) and headless, and the unit sets no `Restart=`, so a single failed start at boot stays failed. Escape hatch is `networking.wireless.enableHardening = false`; recovery is ethernet on `end0`. Worth switching with physical access available.
- The `${pkgs.iw}/bin/iw` udev rule is unaffected by 26.05 dropping the implicit `iw` install, since it references the store path directly.
- home-manager bump looks inert here: none of its 26.05 breaking changes (`programs.ssh.matchBlocks`, `programs.firefox.extensions`, `services.syncthing.passwordFile`) appear in this config, and the shared home config already builds against home-manager `master` on the macOS hosts.
