### PR TITLE
fix(rpi5-homelab): match the renamed wifi interface in the udev rule

### DIFF
--- a/nix/hosts/rpi5-homelab/README.md
+++ b/nix/hosts/rpi5-homelab/README.md
@@ -169,6 +169,15 @@ systemctl is-enabled sshd  # check if sshd is enabled
 systemctl is-active sshd  # check if sshd is running
 ```
 
+The saved profile is pinned to the interface name (`interface-name=wlan0`), and
+that name can change on a nixpkgs bump — systemd 260 renamed the radio `wlan0`
+→ `wld0`, after which the Pi silently stopped reconnecting on boot. Unpin it so
+the profile keeps working across renames:
+
+```sh
+sudo nmcli connection modify "YOUR_SSID" connection.interface-name ""
+```
+
 ## Post-install setup
 
 ### Second NVMe SSD for media storage

--- a/nix/hosts/rpi5-homelab/configuration.nix
+++ b/nix/hosts/rpi5-homelab/configuration.nix
@@ -71,8 +71,11 @@ in {
   };
 
   # Disable WiFi power management to prevent connection drops under high CPU load
+  # NOTE: match `wl*`, not `wlan*` — systemd 260 (nixpkgs 26.05) names the
+  # onboard radio `wld0` via the DeviceTree alias scheme, the same way the
+  # ethernet port is `end0`. A `wlan*` match silently stops applying.
   services.udev.extraRules = ''
-    ACTION=="add", SUBSYSTEM=="net", KERNEL=="wlan*", RUN+="${pkgs.iw}/bin/iw dev $name set power_save off"
+    ACTION=="add", SUBSYSTEM=="net", KERNEL=="wl*", RUN+="${pkgs.iw}/bin/iw dev $name set power_save off"
   '';
 
   # Firewall configuration for homelab services


### PR DESCRIPTION
## Why?

- After [#214](https://github.com/fredrikaverpil/dotfiles/pull/214) moved `rpi5-homelab` to nixpkgs 26.05, the Pi did not reconnect to Wi-Fi on reboot. The cause is not the `wpa_supplicant` hardening that PR flagged as the risk — that unit starts fine. It is [systemd](https://github.com/systemd/systemd) 260 extending DeviceTree-alias naming to wireless devices, the same scheme that already names the ethernet port `end0`:

  ```console
  $ journalctl -b -k | grep renamed
  brcmfmac mmc1:0001:1 wld0: renamed from wlan0

  $ udevadm test-builtin net_id /sys/class/net/wld0
  wld0: DeviceTree identifier: alias_index=0 → "d0"
  ID_NET_NAMING_SCHEME=v260
  ID_NET_NAME_ONBOARD=wld0
  ```

- Two things broke on that rename:
  - The imperative NetworkManager profile carries `interface-name=wlan0`, so it matches no device and never autoconnects (`wld0  wifi  disconnected  --`). This is host state, not in this repo.
  - The power-save udev rule matched `KERNEL=="wlan*"`, so it silently stopped applying — leaving power management on under load, which is exactly what the rule exists to prevent.

## What?

- Match `wl*` instead of `wlan*` in the udev rule: [configuration.nix:75](https://github.com/fredrikaverpil/dotfiles/blob/915b72e2690e361dd02aaed68b51dc1ef8a2a421/nix/hosts/rpi5-homelab/configuration.nix#L75).
- Document the profile pinning in [README.md:172](https://github.com/fredrikaverpil/dotfiles/blob/915b72e2690e361dd02aaed68b51dc1ef8a2a421/nix/hosts/rpi5-homelab/README.md#L172), recommending unpinning over re-creating the profile — `nmcli device wifi connect` just pins the new profile to `wld0`, which breaks again at the next rename.

## Notes

- Verified the rule renders against the host config:

  ```console
  $ nix eval .#nixosConfigurations.rpi5-homelab.config.services.udev.extraRules
  "ACTION==\"add\", SUBSYSTEM==\"net\", KERNEL==\"wl*\", RUN+=\"/nix/store/…-iw-6.17/bin/iw dev $name set power_save off\"…"
  ```

- Wi-Fi itself is fixed out-of-band, not by this PR: `sudo nmcli connection modify Attic connection.interface-name ""`.
