### PR TITLE
feat(nix): pin Homebrew via nix-homebrew

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ code in this repository.
 - **Update all flake inputs**: `nix flake update`, then rebuild
 - **Update only unstable-pinned inputs**: `nix flake update nixpkgs-unstable
   nix-darwin home-manager-unstable llm-agents dotfiles`, then rebuild
+- **Update Homebrew software** (nothing moves until this is run):
+  `nix flake update homebrew-core homebrew-cask homebrew-1password-tap
+  homebrew-nikitabobko-tap homebrew-dustinblackman-tap homebrew-libkrun-krun`,
+  then rebuild
 - **Refresh package-managed CLI tools after an update**: `uv tool upgrade --all`
   and `npm-tools-upgrade`
 - **Nix rebuild**: ask user to run this, NEVER run it yourself
@@ -120,6 +124,14 @@ exact formatter/linter tools and configurations. Formatters are wired up in
 
 - **Neovim is managed by Bob on Darwin**, not nixpkgs — binary is at
   `~/.local/share/bob/nvim-bin/nvim`
+- **Homebrew is pinned via nix-homebrew** (`nix/shared/system/darwin.nix`):
+  brew itself and every tap are mounted read-only from `flake.lock`, so a
+  rebuild never updates brews/casks on its own. Consequences: formulae resolve
+  from the local taps rather than the JSON API, so `brew search`/`brew info`
+  are slower; an ad-hoc `brew install foo` installs the *pinned* version, not
+  the latest; and cask pins can rot, since vendors delete old download
+  artifacts (bump `homebrew-cask` if a cask fails to download). `masApps`
+  cannot be pinned at all.
 - **`stow/` changes take effect immediately** (just re-run
   `cd ~/.dotfiles/stow && stow --target="$HOME" --restow --no-folding --adopt
   shared "$(uname -s)"`) — no Nix rebuild needed

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,23 @@
         "type": "github"
       }
     },
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786348930,
+        "narHash": "sha256-bCQJkbgsAMDp5HQystZLCq11UHiyEuoWbxKulAPYrh8=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "3ecc9eff23feebf1bc73846d74e14a122c93b66f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.16",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "bun2nix": {
       "inputs": {
         "flake-parts": [
@@ -165,6 +182,103 @@
         "type": "github"
       }
     },
+    "homebrew-1password-tap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785445386,
+        "narHash": "sha256-3BbABI9kXuSpl2AMisKjCFzCADV+eTSeoQzZbRWiDmk=",
+        "owner": "1password",
+        "repo": "homebrew-tap",
+        "rev": "2d1dda9fc9436cfe1c0bfcc5070017ce4fe771d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "1password",
+        "repo": "homebrew-tap",
+        "type": "github"
+      }
+    },
+    "homebrew-cask": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786744938,
+        "narHash": "sha256-V5S/rY1INfHbZEWA2/Orqn8y82MAt9wCICQf3eWmhDY=",
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "rev": "51f24cce69baca50c1974d057be314f2d2690033",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-cask",
+        "type": "github"
+      }
+    },
+    "homebrew-core": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786744689,
+        "narHash": "sha256-PwTSFIij8+eWnT9VY6V3icX+sOvaI6MOjLbxxGU2Soo=",
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "rev": "856ceb966d162c846864b9e308a0d48d20d47480",
+        "type": "github"
+      },
+      "original": {
+        "owner": "homebrew",
+        "repo": "homebrew-core",
+        "type": "github"
+      }
+    },
+    "homebrew-dustinblackman-tap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710555187,
+        "narHash": "sha256-7Acx6bL1wvPmqXAXedepmGbLWUhbT8mnNiM6K8oFyNU=",
+        "owner": "dustinblackman",
+        "repo": "homebrew-tap",
+        "rev": "c8960442650b2c8404c04ee698177686bf1ea684",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dustinblackman",
+        "ref": "master",
+        "repo": "homebrew-tap",
+        "type": "github"
+      }
+    },
+    "homebrew-libkrun-krun": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783077189,
+        "narHash": "sha256-hJdXNxQbBx4so7NLdWihJmeB2Ow0NLX1Wt+H28/8ouo=",
+        "owner": "libkrun",
+        "repo": "homebrew-krun",
+        "rev": "00449a906756ea65ab56f824d8e34fafd543198b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libkrun",
+        "repo": "homebrew-krun",
+        "type": "github"
+      }
+    },
+    "homebrew-nikitabobko-tap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784218089,
+        "narHash": "sha256-2FfJuPb9CaXPOU71NWPjoiENUoGQepSr/IkKQMLkFaQ=",
+        "owner": "nikitabobko",
+        "repo": "homebrew-tap",
+        "rev": "13b49a6711cc9d2f4555056b4f7023c8ad2bbb4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nikitabobko",
+        "repo": "homebrew-tap",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "bun2nix": "bun2nix",
@@ -204,6 +318,24 @@
       "original": {
         "owner": "LnL7",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1786686423,
+        "narHash": "sha256-8q3WdB8o3VUI7rOz1OXfioXIaaWbFTAxRJAkWLlfc0s=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "ccabf79a6b9845eb72b51ea1d9c7ce3446350df3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
         "type": "github"
       }
     },
@@ -325,8 +457,15 @@
         "dotfiles": "dotfiles",
         "home-manager-rpi": "home-manager-rpi",
         "home-manager-unstable": "home-manager-unstable",
+        "homebrew-1password-tap": "homebrew-1password-tap",
+        "homebrew-cask": "homebrew-cask",
+        "homebrew-core": "homebrew-core",
+        "homebrew-dustinblackman-tap": "homebrew-dustinblackman-tap",
+        "homebrew-libkrun-krun": "homebrew-libkrun-krun",
+        "homebrew-nikitabobko-tap": "homebrew-nikitabobko-tap",
         "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",
+        "nix-homebrew": "nix-homebrew",
         "nixos-raspberrypi": "nixos-raspberrypi",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,43 @@
       url = "github:fredrikaverpil/dotfiles";
       flake = false;
     };
+
+    # Homebrew pinning: nix-homebrew installs Homebrew itself from a pinned
+    # revision and mounts the taps below read-only from the nix store. That
+    # makes the `homebrew-*` inputs the version pins for every brew/cask —
+    # a rebuild never moves them on its own. Bump them explicitly with:
+    #   nix flake update homebrew-core homebrew-cask homebrew-1password-tap \
+    #     homebrew-nikitabobko-tap homebrew-dustinblackman-tap homebrew-libkrun-krun
+    # then rebuild.
+    #
+    # Caveat: cask pins are best-effort. Formula bottles live on ghcr and are
+    # retained, but casks download from vendor URLs that rot, so an old pin can
+    # fail to install. masApps cannot be pinned at all.
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
+    homebrew-core = {
+      url = "github:homebrew/homebrew-core";
+      flake = false;
+    };
+    homebrew-cask = {
+      url = "github:homebrew/homebrew-cask";
+      flake = false;
+    };
+    homebrew-1password-tap = {
+      url = "github:1password/homebrew-tap";
+      flake = false;
+    };
+    homebrew-nikitabobko-tap = {
+      url = "github:nikitabobko/homebrew-tap";
+      flake = false;
+    };
+    homebrew-dustinblackman-tap = {
+      url = "github:dustinblackman/homebrew-tap/master";
+      flake = false;
+    };
+    homebrew-libkrun-krun = {
+      url = "github:libkrun/homebrew-krun";
+      flake = false;
+    };
   };
 
   outputs =

--- a/nix/hosts/zap/configuration.nix
+++ b/nix/hosts/zap/configuration.nix
@@ -34,9 +34,9 @@ in
   host.extraPackages = with pkgs; [
   ];
 
-  host.extraTaps = [
-    "libkrun/krun" # krunkit
-  ];
+  host.extraTaps = {
+    "libkrun/krun" = inputs.homebrew-libkrun-krun; # krunkit
+  };
 
   host.extraBrews = [
     # podman added here as it also adds podman-mac-helper (not installed if installed via nix)

--- a/nix/lib/systems.nix
+++ b/nix/lib/systems.nix
@@ -6,6 +6,7 @@
         [
           {nixpkgs.overlays = [(import ../shared/overlays)];}
           inputs.home-manager-unstable.darwinModules.home-manager # unstable pkgs
+          inputs.nix-homebrew.darwinModules.nix-homebrew
           ./users.nix
           ../shared/system/darwin.nix
           ../shared/system/common.nix

--- a/nix/shared/system/darwin.nix
+++ b/nix/shared/system/darwin.nix
@@ -34,8 +34,6 @@ let
       parts = lib.splitString "/" name;
     in
     "${lib.head parts}/homebrew-${lib.last parts}";
-
-  trustedTapArgs = lib.concatMapStringsSep " " lib.escapeShellArg tapNames;
 in
 {
   options = {
@@ -83,6 +81,8 @@ in
       user = config.homebrew.user;
       mutableTaps = false;
       autoMigrate = true; # adopt the existing /opt/homebrew instead of reinstalling
+      # Trust third-party taps before `brew bundle` loads formulae from them.
+      trust.taps = tapNames;
       taps = {
         "homebrew/homebrew-core" = inputs.homebrew-core;
         "homebrew/homebrew-cask" = inputs.homebrew-cask;
@@ -155,20 +155,6 @@ in
       }
       // config.host.extraMasApps;
     };
-
-    system.activationScripts.homebrew.text = lib.mkIf config.homebrew.enable (
-      lib.mkBefore ''
-        # Trust configured Homebrew taps before `brew bundle` loads formulae from them.
-        if [ -f "${config.homebrew.prefix}/bin/brew" ]; then
-          PATH="${config.homebrew.prefix}/bin:$PATH" sudo \
-            --preserve-env=PATH \
-            --user=${lib.escapeShellArg config.homebrew.user} \
-            --set-home \
-            env HOMEBREW_NO_AUTO_UPDATE=1 \
-            brew trust --quiet --tap ${trustedTapArgs}
-        fi
-      ''
-    );
 
     # NOTE: Run socktainer with `socktainer --no-check-compatibility` manually during
     # the experimentation phase.

--- a/nix/shared/system/darwin.nix
+++ b/nix/shared/system/darwin.nix
@@ -14,18 +14,28 @@ let
       trusted = true;
     }) taps;
 
-  homebrewTaps = lib.unique (
-    [
-      "dustinblackman/tap"
-      # "joshmedeski/sesh"
-      "1password/tap"
-      "nikitabobko/tap"
-      # "sst/tap" # for opencode
-    ]
-    ++ config.host.extraTaps
-  );
+  # Single source of truth for taps: brew's short name -> pinned flake input.
+  # Both `homebrew.taps` and `nix-homebrew.taps` are derived from this, so the
+  # two name forms cannot drift apart.
+  homebrewTaps = {
+    "dustinblackman/tap" = inputs.homebrew-dustinblackman-tap;
+    "1password/tap" = inputs.homebrew-1password-tap;
+    "nikitabobko/tap" = inputs.homebrew-nikitabobko-tap;
+  }
+  // config.host.extraTaps;
 
-  trustedTapArgs = lib.concatMapStringsSep " " lib.escapeShellArg homebrewTaps;
+  tapNames = lib.attrNames homebrewTaps;
+
+  # nix-homebrew wants the full repo name: "user/tap" -> "user/homebrew-tap".
+  # homebrew-core and homebrew-cask are already in that form.
+  fullTapName =
+    name:
+    let
+      parts = lib.splitString "/" name;
+    in
+    "${lib.head parts}/homebrew-${lib.last parts}";
+
+  trustedTapArgs = lib.concatMapStringsSep " " lib.escapeShellArg tapNames;
 in
 {
   options = {
@@ -36,9 +46,12 @@ in
     };
 
     host.extraTaps = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
-      description = "Additional homebrew taps for this host";
+      type = lib.types.attrsOf lib.types.path;
+      default = { };
+      description = ''
+        Additional homebrew taps for this host, as brew's short name
+        ("user/tap") mapped to the pinned `flake = false` input providing it.
+      '';
     };
 
     host.extraCasks = lib.mkOption {
@@ -61,15 +74,34 @@ in
   };
 
   config = {
+    # Homebrew itself and all taps come from pinned flake inputs, so nothing
+    # moves until `nix flake update homebrew-*` (see flake.nix). nix-homebrew
+    # sets HOMEBREW_NO_INSTALL_FROM_API and HOMEBREW_NO_AUTO_UPDATE for us.
+    nix-homebrew = {
+      enable = true;
+      enableRosetta = false;
+      user = config.homebrew.user;
+      mutableTaps = false;
+      autoMigrate = true; # adopt the existing /opt/homebrew instead of reinstalling
+      taps = {
+        "homebrew/homebrew-core" = inputs.homebrew-core;
+        "homebrew/homebrew-cask" = inputs.homebrew-cask;
+      }
+      // lib.mapAttrs' (name: input: lib.nameValuePair (fullTapName name) input) homebrewTaps;
+    };
+
     homebrew = {
       enable = true;
       onActivation = {
-        autoUpdate = true;
+        # Never update Homebrew on switch — versions come from the pinned taps.
+        # `upgrade` is deterministic against frozen taps and is what makes a
+        # switch converge on the pins after a `nix flake update`.
+        autoUpdate = false;
         upgrade = true;
         cleanup = "zap";
       };
 
-      taps = trustedTaps homebrewTaps;
+      taps = trustedTaps tapNames;
 
       brews = [
         # Packages not available in nixpkgs


### PR DESCRIPTION
## Why?

- `homebrew.onActivation.autoUpdate = true` meant every `darwin-rebuild switch` ran `brew update` and upgraded every formula and cask, so a rebuild motivated by an unrelated Nix change could silently move Ghostty, Slack, podman or krunkit.
- Nothing Homebrew installed was pinned, so a new machine building from the same lock got different versions.
- [nix-homebrew](https://github.com/zhaofengli/nix-homebrew) pins Homebrew itself and takes taps as `flake = false` inputs, moving formula/cask *definitions* — and hence versions — into `flake.lock`.

## What?

- Add `nix-homebrew` plus pinned `homebrew-*` tap inputs (core, cask, 1password, nikitabobko, dustinblackman, libkrun/krun) and wire the module into `mkDarwin`.
- Set `mutableTaps = false` and `onActivation.autoUpdate = false`; `upgrade` stays on since against frozen taps it is deterministic and is what converges a switch onto the pins.
- Change `host.extraTaps` to an attrset of short tap name → flake input, and derive both `homebrew.taps` and `nix-homebrew.taps` from one source so the two naming forms cannot drift:

  ```nix
  host.extraTaps = {
    "libkrun/krun" = inputs.homebrew-libkrun-krun; # krunkit
  };
  ```

- Replace the hand-rolled `brew trust` activation script with [`nix-homebrew.trust.taps`](https://github.com/zhaofengli/nix-homebrew/blob/main/modules/default.nix), which runs the same command.

## Notes

- Updates are now explicit: `nix flake update homebrew-core homebrew-cask homebrew-1password-tap homebrew-nikitabobko-tap homebrew-dustinblackman-tap homebrew-libkrun-krun`, then rebuild. Documented in `CLAUDE.md`.
- Reproducibility is best-effort: formula bottles are retained on ghcr, but casks download from vendor URLs that rot, and `masApps` cannot be pinned at all.
- Formulae now resolve from local taps instead of the JSON API — `brew search`/`info` are slower and an ad-hoc `brew install foo` gets the pinned version.
- Verified: `nix flake check` passes and both `zap` and `plumbus` systems build. Not yet switched on a real machine — roll out `zap` first, verify `brew list --versions` is unchanged across a second plain switch, then `plumbus`. `autoMigrate = true` adopts the existing `/opt/homebrew` rather than reinstalling, so a revert is safe.