### PR TITLE
feat(wily-vm): add DankCalendar and fix never-expire notifications

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,6 +50,43 @@
         "type": "github"
       }
     },
+    "dank-qml-common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788219423,
+        "narHash": "sha256-U4WBPh+pfM2IRF+IOWWHaw3cWaR1kYtl+Rdp7i9S2OQ=",
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "rev": "a9ae19facd460a4150da269dafcfb044b0dd9eea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "type": "github"
+      }
+    },
+    "dankcalendar": {
+      "inputs": {
+        "dank-qml-common": "dank-qml-common",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788789613,
+        "narHash": "sha256-0dUlxg2DvBjMd+UimytDBHOspB4uDtY104f0Ejgiwhs=",
+        "owner": "AvengeMedia",
+        "repo": "dankcalendar",
+        "rev": "fb812604a48f4763f938a1ff6a1fee9f6fef81a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dankcalendar",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -322,6 +359,7 @@
     },
     "root": {
       "inputs": {
+        "dankcalendar": "dankcalendar",
         "disko": "disko",
         "dotfiles": "dotfiles",
         "home-manager-rpi": "home-manager-rpi",

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,10 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       inputs.home-manager.follows = "home-manager-unstable";
     };
+    dankcalendar = {
+      url = "github:AvengeMedia/dankcalendar";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
     dotfiles = {
       # Used by home-manager for dotfiles bootstrapping.
       url = "github:fredrikaverpil/dotfiles";

--- a/nix/hosts/wily-vm/CLAUDE.md
+++ b/nix/hosts/wily-vm/CLAUDE.md
@@ -25,6 +25,18 @@ previous states.
   speculative plugin framework.
 - Prefer purpose-built applications to large bespoke panels for infrequent
   tasks.
+- Calendar credentials and bearer feed URLs are private user state, never
+  Nix/Stow values. Keep Secret Service available before starting `dcal`: its
+  local encrypted-keyring fallback uses a fixed password. Verify keyring use
+  before adding real accounts; the service's startup probe does not guard
+  manually launched instances. Password login unlocks GNOME Keyring via PAM;
+  fingerprint-only login cannot supply that password.
+- On first use, GNOME Keyring can advertise `login` without exporting the
+  collection when keyring creation follows D-Bus startup. `OpenSession` alone
+  misses this; also probe the collection. Recover by restarting the keyring
+  daemon and unlocking it, then retry account setup. Do not delete keyring
+  files. Console logout may leave the daemon alive while SSH keeps the user
+  manager running.
 - Selection requires exactly one session marker: `NIRI_SOCKET` or
   `HYPRLAND_INSTANCE_SIGNATURE`. Missing/ambiguous markers are errors, never an
   implicit Hyprland fallback.

--- a/nix/hosts/wily-vm/desktop.nix
+++ b/nix/hosts/wily-vm/desktop.nix
@@ -1,4 +1,10 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
 let
   # UTM's virgl lacks the desktop GL version Ghostty requires; keep software GL scoped to it.
   ghostty-softgl = pkgs.symlinkJoin {
@@ -69,6 +75,12 @@ let
   };
 in
 {
+  imports = [ inputs.dankcalendar.nixosModules.default ];
+
+  programs.dank-calendar.enable = true;
+  # OAuth tokens stay in the user's keyring, unlocked by the console login PAM stack.
+  services.gnome.gnome-keyring.enable = true;
+
   programs.hyprland = {
     enable = true;
     withUWSM = true;
@@ -126,6 +138,39 @@ in
     serviceConfig = {
       ExecStart = "${pkgs.quickshell}/bin/quickshell";
       Restart = "on-failure";
+    };
+  };
+
+  # Keep the upstream systemd option off: its unit orders after graphical-session.target.
+  # Sync and reminders outlive the calendar window and run independently of our shell.
+  systemd.user.services.dcal = {
+    description = "DankCalendar sync and reminders";
+    partOf = [ "graphical-session.target" ];
+    after = [
+      "dbus.socket"
+      "quickshell.service"
+      "wayland-wm@hyprland.desktop.service"
+      "wayland-wm@niri.service"
+      "wayland-session-waitenv.service"
+    ];
+    wantedBy = [
+      "wayland-session@hyprland.desktop.target"
+      "wayland-session@niri.target"
+    ];
+    # NixOS pins a sparse user-unit PATH; inherit UWSM's session PATH so dcal can
+    # launch its Quickshell UI and open OAuth URLs with the session's tools.
+    environment.PATH = lib.mkForce null;
+    serviceConfig = {
+      # OpenSession prevents the weak local fallback; the collection probe catches broken first-use initialization.
+      ExecStartPre = [
+        "${pkgs.systemd}/bin/busctl --user --timeout=15 --quiet call org.freedesktop.secrets /org/freedesktop/secrets org.freedesktop.Secret.Service OpenSession sv plain s \"\""
+        "${pkgs.systemd}/bin/busctl --user --timeout=15 --quiet get-property org.freedesktop.secrets /org/freedesktop/secrets/collection/login org.freedesktop.Secret.Collection Locked"
+      ];
+      ExecStart = "${lib.getExe config.programs.dank-calendar.package} run --session --hidden";
+      Restart = "on-failure";
+      RestartSec = "2s";
+      Slice = "app.slice";
+      UMask = "0077";
     };
   };
 

--- a/stow/host/wily-vm/.config/quickshell/Ui/BarButton.qml
+++ b/stow/host/wily-vm/.config/quickshell/Ui/BarButton.qml
@@ -13,7 +13,7 @@ Rectangle {
   signal activated
   signal secondary
 
-  implicitWidth: visible ? 28 : 0
+  implicitWidth: visible ? Math.max(28, btnLabel.implicitWidth + 12) : 0
   width: implicitWidth
   height: 24
   radius: 4

--- a/stow/host/wily-vm/.config/quickshell/plugins/bar/Bar.qml
+++ b/stow/host/wily-vm/.config/quickshell/plugins/bar/Bar.qml
@@ -96,7 +96,9 @@ Scope {
         anchors.right: powerButton.left
         anchors.verticalCenter: parent.verticalCenter
         anchors.rightMargin: 4
-        label: bar.shell.notifications.doNotDisturb ? "󰂛" : "󰂚"
+        readonly property int pending: bar.shell.notifications.historyRows.length
+        label: (bar.shell.notifications.doNotDisturb ? "󰂛" : "󰂚")
+          + (notificationButton.pending > 0 ? " " + notificationButton.pending : "")
         onActivated: bar.shell.notifications.toggleHistory()
       }
 

--- a/stow/host/wily-vm/.config/quickshell/plugins/notifications/NotificationLogic.js
+++ b/stow/host/wily-vm/.config/quickshell/plugins/notifications/NotificationLogic.js
@@ -26,8 +26,10 @@ function snapshotOf(notification, timestamp) {
 function durationFor(notification, lowUrgency, criticalUrgency) {
   if (notification.urgency === criticalUrgency || notification.resident) return 0
 
+  // Zero is the spec's "never expire"; negative or unparseable means server default.
   var requested = Number(notification.expireTimeout)
-  if (!isFinite(requested) || requested <= 0) requested = 0
+  if (requested === 0) return 0
+  if (!isFinite(requested) || requested < 0) requested = 0
 
   var minimum = notification.urgency === lowUrgency ? 5000 : 8000
   return Math.min(30000, Math.max(minimum, requested))

--- a/stow/host/wily-vm/.config/quickshell/tests/tst_NotificationLogic.qml
+++ b/stow/host/wily-vm/.config/quickshell/tests/tst_NotificationLogic.qml
@@ -30,5 +30,7 @@ TestCase {
     compare(Notification.durationFor({ urgency: 1, expireTimeout: 1 }, low, critical), 8000)
     compare(Notification.durationFor({ urgency: 1, expireTimeout: 99999 }, low, critical), 30000)
     compare(Notification.durationFor({ urgency: 1, expireTimeout: "invalid" }, low, critical), 8000)
+    compare(Notification.durationFor({ urgency: 1, expireTimeout: 0 }, low, critical), 0)
+    compare(Notification.durationFor({ urgency: 1, expireTimeout: -1 }, low, critical), 8000)
   }
 }


### PR DESCRIPTION
## Why?

- No calendar on `wily-vm`; wanted Google Calendar with reminders that fire even when the calendar window is closed.
- Reminder toasts carry Snooze/Open buttons, but they vanished after 8s before anyone could press them.
- The notification bell gave no indication that anything was waiting in history.

## What?

- Add [DankCalendar](https://github.com/AvengeMedia/dankcalendar) via its flake input, running `dcal` as our own user unit bound to the compositor session targets rather than the upstream one that orders after `graphical-session.target` — sync and reminders must outlive the window ([desktop.nix:144](https://github.com/fredrikaverpil/dotfiles/blob/097cec7b22f236e32f4c90635d28f7a1f8538501/nix/hosts/wily-vm/desktop.nix#L144)).
- Honour `expire_timeout: 0` in [NotificationLogic.js:26](https://github.com/fredrikaverpil/dotfiles/blob/097cec7b22f236e32f4c90635d28f7a1f8538501/stow/host/wily-vm/.config/quickshell/plugins/notifications/NotificationLogic.js#L26).
- Show the history count on the bell, do-not-disturb included ([Bar.qml:99](https://github.com/fredrikaverpil/dotfiles/blob/097cec7b22f236e32f4c90635d28f7a1f8538501/stow/host/wily-vm/.config/quickshell/plugins/bar/Bar.qml#L99)).

The notification fix, in short — the [spec](https://specifications.freedesktop.org/notification-spec/latest/protocol.html) gives `expire_timeout` two distinct values that we collapsed into one:

```js
// -1 means "server decides", 0 means "never expire". Both hit the floor.
if (!isFinite(requested) || requested <= 0) requested = 0
return Math.min(30000, Math.max(minimum, requested))   // 0 -> 8000
```

Our shell is the notification server, so honouring `0` is our obligation. [dcal](https://github.com/AvengeMedia/dankcalendar) sends it correctly for `reminderPersist`.

## Notes

- Verified end to end on `wily-vm`: a real Google Calendar event fired a real reminder into the shell at its scheduled trigger.
- `qml-test` 114 passed, `qml-lint` clean, `shell-smoke niri --panels` all PASS. Only exercised under niri; **Hyprland is pending**, as is the ThinkPad.
- Per-app notification rules (severity/lifetime keyed on `desktopEntry`) are a natural follow-up, deliberately not built here.